### PR TITLE
feat: Branches tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can optionally configure the following options through your jj config:
 - `lazyjj.higlight-color`: Changes the highlight color. Can use named colors. Defaults to `#323264`
 - `lazyjj.diff-format`: Change the default diff format. Can be `color-words` or `git`. Defaults to `color_words`
   - If `lazyjj.diff-format` is not set but `ui.diff.format` is, the latter will be used
+- `lazyjj.branch-prefix`: Change the branch name prefix for generated branch names. Defaults to `push-`
+  - If `lazyjj.branch-prefix` is not set but `git.push-branch-prefix` is, the latter will be used
 
 Example: `jj config set --user lazyjj.diff-format "color-words"` (for storing in [user config file](https://martinvonz.github.io/jj/latest/config/#user-config-file), repo config is also supported)
 
@@ -76,12 +78,22 @@ To use a different repository: `lazyjj --path ~/path/to/repo`
 - Describe the highlighted change with `d` (`jj describe`)
   - Save with `Ctrl+s`
   - Cancel with `Esc`
+- Set a branch to the highlighted change with `b`
+  - Scroll in branch list with `j`/`k`
+  - Create a new branch with `c`
+  - Use auto-generated name with `g`
 
 ### Files tab
 
 - Select current change with `@`
 - Change right panel diff format between color words (default) and Git with `p`
 - Toggle right panel wrapping with `w`
+
+### Branches tab
+
+- Create a branch with `c`
+- Rename a branch with `r`
+- Delete a branch with `d`
 
 ### Command log tab
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::{
     commander::Commander,
     env::Env,
-    ui::{command_log::CommandLog, files::Files, log::Log, ComponentAction},
+    ui::{branches::Branches, command_log::CommandLog, files::Files, log::Log, ComponentAction},
 };
 use anyhow::Result;
 use core::fmt;
@@ -10,6 +10,7 @@ use core::fmt;
 pub enum Tab {
     Log,
     Files,
+    Branches,
     CommandLog,
 }
 
@@ -18,13 +19,14 @@ impl fmt::Display for Tab {
         match self {
             Tab::Log => write!(f, "Log"),
             Tab::Files => write!(f, "Files"),
+            Tab::Branches => write!(f, "Branches"),
             Tab::CommandLog => write!(f, "Command Log"),
         }
     }
 }
 
 impl Tab {
-    pub const VALUES: [Self; 3] = [Tab::Log, Tab::Files, Tab::CommandLog];
+    pub const VALUES: [Self; 4] = [Tab::Log, Tab::Files, Tab::Branches, Tab::CommandLog];
 }
 
 pub struct App<'a> {
@@ -32,6 +34,7 @@ pub struct App<'a> {
     pub current_tab: Tab,
     pub log: Log<'a>,
     pub files: Files,
+    pub branches: Branches<'a>,
     pub command_log: CommandLog,
     pub textarea_active: bool,
 }
@@ -39,11 +42,13 @@ pub struct App<'a> {
 impl App<'_> {
     pub fn new<'a>(env: Env, commander: &mut Commander) -> Result<App<'a>> {
         let current_head = &commander.get_current_head()?;
+        // TODO: Lazy load tabs on open
         Ok(App {
             env,
             current_tab: Tab::Log,
             log: Log::new(commander)?,
             files: Files::new(commander, current_head)?,
+            branches: Branches::new(commander)?,
             command_log: CommandLog::new(commander)?,
             textarea_active: false,
         })
@@ -58,6 +63,7 @@ impl App<'_> {
             ComponentAction::ViewFiles(head) => {
                 self.files.set_head(commander, &head)?;
                 self.current_tab = Tab::Files;
+                self.get_current_component_mut().switch(commander)?;
             }
             ComponentAction::ChangeHead(head) => {
                 self.files.set_head(commander, &head)?;

--- a/src/commander/branches.rs
+++ b/src/commander/branches.rs
@@ -1,0 +1,231 @@
+use crate::{
+    commander::{CommandError, Commander, RemoveEndLine},
+    env::DiffFormat,
+};
+use ansi_to_tui::IntoText;
+use anyhow::Result;
+use lazy_static::lazy_static;
+use ratatui::text::Text;
+use regex::Regex;
+use std::fmt::Display;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Branch {
+    pub name: String,
+    pub remote: Option<String>,
+}
+
+impl Display for Branch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut text = self.name.clone();
+        if let Some(remote) = self.remote.as_ref() {
+            text.push('@');
+            text.push_str(remote);
+        }
+        write!(f, "{}", text)
+    }
+}
+
+// Template which outputs `[name@remote]`. Used to parse data from branch list
+const BRANCH_TEMPLATE: &str = r#""[" ++ name ++ "@" ++ remote ++ "]""#;
+lazy_static! {
+    // Regex to parse branch
+    static ref BRANCH_REGEX: Regex = Regex::new(r"^\[(.*)@(.*)\]$").unwrap();
+}
+
+fn parse_branch(text: &str) -> Option<Branch> {
+    let captured = BRANCH_REGEX.captures(text);
+    captured.as_ref().and_then(|captured| {
+        let name = captured.get(1);
+        let remote = captured.get(2);
+
+        if let Some(name) = name
+            && let Some(remote) = remote
+        {
+            let remote = remote.as_str().to_owned();
+            Some(Branch {
+                remote: if remote.is_empty() {
+                    None
+                } else {
+                    Some(remote)
+                },
+                name: name.as_str().to_owned(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
+#[derive(Clone, Debug)]
+pub enum BranchLine {
+    Unparsable(String),
+    Parsed { text: String, branch: Branch },
+}
+
+impl BranchLine {
+    pub fn to_text(&self) -> Result<Text, ansi_to_tui::Error> {
+        match self {
+            BranchLine::Unparsable(text) => text.to_text(),
+            BranchLine::Parsed { text, .. } => text.to_text(),
+        }
+    }
+}
+
+impl Commander {
+    /// Get branches.
+    /// Maps to `jj branch list`
+    pub fn get_branches(&mut self, show_all: bool) -> Result<Vec<BranchLine>, CommandError> {
+        let mut args = vec![];
+        if show_all {
+            args.push("--all-remotes");
+        }
+        let branches_colored = self.execute_jj_command(
+            [
+                vec![
+                    "branch",
+                    "list",
+                    "--config-toml",
+                    // Override format_ref_targets to not list conflicts
+                    r#"
+                            template-aliases.'format_ref_targets(ref)' = '''
+                                if(ref.conflict(),
+                                  " " ++ label("conflict", "(conflicted)"),
+                                  ": " ++ format_commit_summary_with_refs(ref.normal_target(), ""),
+                                )
+                            '''
+                        "#,
+                ],
+                args.clone(),
+            ]
+            .concat(),
+            true,
+            true,
+        )?;
+
+        let branches: Vec<BranchLine> = self
+            .execute_jj_command(
+                [
+                    vec![
+                        "branch",
+                        "list",
+                        "-T",
+                        &format!(r#"{} ++ "\n""#, BRANCH_TEMPLATE),
+                    ],
+                    args,
+                ]
+                .concat(),
+                false,
+                true,
+            )?
+            .lines()
+            .zip(branches_colored.lines())
+            .map(|(line, line_colored)| match parse_branch(line) {
+                Some(branch) => BranchLine::Parsed {
+                    text: line_colored.to_owned(),
+                    branch,
+                },
+                None => BranchLine::Unparsable(line_colored.to_owned()),
+            })
+            .collect();
+
+        Ok(branches)
+    }
+
+    pub fn get_branches_list(&mut self, show_all: bool) -> Result<Vec<Branch>, CommandError> {
+        let mut args = vec![
+            "branch".to_owned(),
+            "list".to_owned(),
+            "-T".to_owned(),
+            format!(r#"if(present, {} ++ "\n", "")"#, BRANCH_TEMPLATE),
+        ];
+        if show_all {
+            args.push("--all-remotes".to_owned());
+        }
+
+        let branches: Vec<Branch> = self
+            .execute_jj_command(args, false, true)?
+            .lines()
+            .filter_map(parse_branch)
+            .collect();
+
+        Ok(branches)
+    }
+
+    /// Get branch details.
+    /// Maps to `jj show <branch>`
+    pub fn get_branch_show(
+        &mut self,
+        branch: &Branch,
+        diff_format: &DiffFormat,
+    ) -> Result<String, CommandError> {
+        Ok(self
+            .execute_jj_command(
+                vec!["show", &branch.to_string(), diff_format.get_arg()],
+                true,
+                true,
+            )?
+            .remove_end_line())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use insta::assert_debug_snapshot;
+
+    use crate::commander::tests::TestRepo;
+
+    use super::*;
+
+    #[test]
+    fn get_branches() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        let branch = test_repo.commander.create_branch("test")?;
+        let branches = test_repo.commander.get_branches(false)?;
+
+        assert_eq!(branches.len(), 1);
+        assert_eq!(
+            branches.first().and_then(|branch| match branch {
+                BranchLine::Parsed { branch, .. } => Some(branch),
+                _ => None,
+            }),
+            Some(&branch)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_branches_list() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        let branch = test_repo.commander.create_branch("test")?;
+        let branches = test_repo.commander.get_branches_list(false)?;
+
+        assert_eq!(branches, [branch]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_branch_show() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        let branch = test_repo.commander.create_branch("test")?;
+        let branch_show = test_repo
+            .commander
+            .get_branch_show(&branch, &DiffFormat::default())?;
+
+        let mut settings = insta::Settings::clone_current();
+        settings.add_filter(r"Commit ID: [0-9a-fA-F]{40}", "Commit ID: [COMMIT_ID]");
+        settings.add_filter(r"Change ID: [k-z]{32}", "Change ID: [Change ID]");
+        settings.add_filter(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", "([DATE_TIME])");
+        let _bound = settings.bind_to_scope();
+
+        assert_debug_snapshot!(branch_show);
+
+        Ok(())
+    }
+}

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -1,4 +1,4 @@
-use crate::commander::{ids::CommitId, Commander};
+use crate::commander::{branches::Branch, ids::CommitId, CommandError, Commander};
 
 use anyhow::{Context, Result};
 
@@ -25,6 +25,57 @@ impl Commander {
     pub fn run_describe(&mut self, commit_id: &CommitId, message: &str) -> Result<()> {
         self.execute_void_jj_command(vec!["describe", commit_id.as_str(), "-m", message])
             .context("Failed executing jj describe")
+    }
+
+    /// Create branch. Maps to `jj branch create <name>`
+    pub fn create_branch(&mut self, name: &str) -> Result<Branch, CommandError> {
+        self.execute_void_jj_command(vec!["branch", "create", name])?;
+        // jj only creates local branches
+        Ok(Branch {
+            name: name.to_owned(),
+            remote: None,
+        })
+    }
+
+    /// Create branch pointing to commit. Maps to `jj branch create <name> -r <revision>`
+    pub fn create_branch_commit(
+        &mut self,
+        name: &str,
+        commit_id: &CommitId,
+    ) -> Result<Branch, CommandError> {
+        self.execute_void_jj_command(vec!["branch", "create", name, "-r", commit_id.as_str()])?;
+        // jj only creates local branches
+        Ok(Branch {
+            name: name.to_owned(),
+            remote: None,
+        })
+    }
+
+    /// Set branch pointing to commit. Maps to `jj branch set <name> -r <revision>`
+    pub fn set_branch_commit(
+        &mut self,
+        name: &str,
+        commit_id: &CommitId,
+    ) -> Result<(), CommandError> {
+        // TODO: Maybe don't do --allow-backwards by default?
+        self.execute_void_jj_command(vec![
+            "branch",
+            "set",
+            name,
+            "-r",
+            commit_id.as_str(),
+            "--allow-backwards",
+        ])
+    }
+
+    /// Rename branch. Maps to `jj branch rename <old> <new>`
+    pub fn rename_branch(&mut self, old: &str, new: &str) -> Result<(), CommandError> {
+        self.execute_void_jj_command(vec!["branch", "rename", old, new])
+    }
+
+    /// Delete branch. Maps to `jj branch delete <name>`
+    pub fn delete_branch(&mut self, name: &str) -> Result<(), CommandError> {
+        self.execute_void_jj_command(vec!["branch", "delete", name])
     }
 }
 
@@ -121,6 +172,144 @@ mod tests {
 
         let head = test_repo.commander.get_current_head()?.commit_id;
         assert_eq!(test_repo.commander.get_commit_description(&head)?, "AAA");
+
+        Ok(())
+    }
+
+    #[test]
+    fn create_branch() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        let branch = test_repo.commander.create_branch("test")?;
+        let branches = test_repo.commander.get_branches_list(false)?;
+
+        assert_eq!(branches, [branch]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn create_branch_commit() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        // Create new change, since by default `jj branch create` uses current change
+        let head = test_repo.commander.get_current_head()?;
+        test_repo.commander.run_new(&head.commit_id)?;
+        assert_ne!(head, test_repo.commander.get_current_head()?);
+
+        let branch = test_repo
+            .commander
+            .create_branch_commit("test", &head.commit_id)?;
+
+        let log = test_repo.commander.execute_jj_command(
+            [
+                "log",
+                "--limit",
+                "1",
+                "--no-graph",
+                "-T",
+                "commit_id",
+                "-r",
+                &branch.name,
+            ],
+            false,
+            true,
+        )?;
+
+        assert_eq!(head.commit_id.to_string(), log);
+
+        Ok(())
+    }
+
+    #[test]
+    fn set_branch_commit() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        // Create new change, since by default `jj branch create` uses current change
+        let old_head = test_repo.commander.get_current_head()?;
+        test_repo.commander.run_new(&old_head.commit_id)?;
+        let new_head = test_repo.commander.get_current_head()?;
+        assert_ne!(old_head, new_head);
+
+        let branch = test_repo.commander.create_branch("test")?;
+
+        let log = test_repo.commander.execute_jj_command(
+            [
+                "log",
+                "--limit",
+                "1",
+                "--no-graph",
+                "-T",
+                "commit_id",
+                "-r",
+                &branch.name,
+            ],
+            false,
+            true,
+        )?;
+
+        assert_eq!(new_head.commit_id.to_string(), log);
+
+        test_repo
+            .commander
+            .set_branch_commit(&branch.name, &old_head.commit_id)?;
+
+        let log = test_repo.commander.execute_jj_command(
+            [
+                "log",
+                "--limit",
+                "1",
+                "--no-graph",
+                "-T",
+                "commit_id",
+                "-r",
+                &branch.name,
+            ],
+            false,
+            true,
+        )?;
+
+        assert_eq!(old_head.commit_id.to_string(), log);
+
+        Ok(())
+    }
+
+    #[test]
+    fn rename_branch() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        let branch = test_repo.commander.create_branch("test1")?;
+
+        let branches = test_repo.commander.get_branches_list(false)?;
+        assert_eq!(branches, [branch.clone()]);
+
+        test_repo.commander.rename_branch(&branch.name, "test2")?;
+
+        let branches = test_repo.commander.get_branches_list(false)?;
+        assert_eq!(
+            branches,
+            [Branch {
+                name: "test2".to_owned(),
+                remote: None
+            }]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn delete_branch() -> Result<()> {
+        let mut test_repo = TestRepo::new()?;
+
+        let branch = test_repo.commander.create_branch("test")?;
+
+        let branches = test_repo.commander.get_branches_list(false)?;
+        assert_eq!(branches, [branch.clone()]);
+
+        test_repo.commander.delete_branch(&branch.name)?;
+
+        let branches = test_repo.commander.get_branches_list(false)?;
+        assert_eq!(branches, []);
 
         Ok(())
     }

--- a/src/commander/snapshots/lazyjj__commander__branches__tests__get_branch_show.snap
+++ b/src/commander/snapshots/lazyjj__commander__branches__tests__get_branch_show.snap
@@ -1,0 +1,5 @@
+---
+source: src/commander/branches.rs
+expression: branch_show
+---
+"Commit ID: [COMMIT_ID]\nChange ID: [Change ID]\nBranches: test test@git\nAuthor: lazyjj <lazyjj@example.com> (([DATE_TIME]))\nCommitter: lazyjj <lazyjj@example.com> (([DATE_TIME]))\n\n    (no description set)\n"

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn run_app<B: Backend>(
                                 )
                         }) {
                             app.current_tab = *tab;
-                            app.get_current_component_mut().reset(commander)?;
+                            app.get_current_component_mut().switch(commander)?;
                             continue;
                         }
                     }

--- a/src/ui/branch_set_popup.rs
+++ b/src/ui/branch_set_popup.rs
@@ -1,0 +1,297 @@
+use ansi_to_tui::IntoText;
+use anyhow::bail;
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Style, Stylize},
+    text::{Span, Text},
+    widgets::{Block, BorderType, Borders, Clear, List, ListState, Paragraph},
+};
+use tui_textarea::TextArea;
+
+use crate::{
+    commander::{
+        branches::Branch,
+        ids::{ChangeId, CommitId},
+        Commander,
+    },
+    env::Config,
+    ui::utils::{centered_rect, centered_rect_line_height},
+};
+
+enum BranchSetOption {
+    CreateBranch,
+    // Name, exists
+    GeneratedName(String, bool),
+    Branch(Branch),
+    Error(String),
+}
+
+pub struct BranchSetPopup<'a> {
+    pub change_id: Option<ChangeId>,
+    commit_id: CommitId,
+    options: Vec<BranchSetOption>,
+    list_state: ListState,
+    list_height: u16,
+    config: Config,
+    creating: Option<TextArea<'a>>,
+}
+
+fn generate_options(
+    commander: &mut Commander,
+    change_id: Option<&ChangeId>,
+) -> Vec<BranchSetOption> {
+    let branches = commander.get_branches_list(false).map(|branches| {
+        branches
+            .into_iter()
+            .filter(|branch| branch.remote.is_none())
+            .collect::<Vec<Branch>>()
+    });
+    let mut options = vec![BranchSetOption::CreateBranch];
+
+    if let Some(change_id) = change_id {
+        let generated_name = generate_name(&commander.env.config.branch_prefix(), change_id);
+        let exists = if let Ok(branches) = branches.as_ref() {
+            branches.iter().any(|branch| branch.name == generated_name)
+        } else {
+            false
+        };
+        options.push(BranchSetOption::GeneratedName(generated_name, exists));
+    }
+
+    match branches.as_ref() {
+        Ok(branches) => {
+            for branch in branches.iter().filter(|branch| branch.remote.is_none()) {
+                options.push(BranchSetOption::Branch(branch.clone()))
+            }
+        }
+        Err(err) => options.push(BranchSetOption::Error(err.to_string())),
+    }
+
+    options
+}
+
+fn generate_name(git_push_branch_prefix: &str, change_id: &ChangeId) -> String {
+    format!("{git_push_branch_prefix}{change_id}")
+}
+
+impl BranchSetPopup<'_> {
+    pub fn new(
+        config: Config,
+        commander: &mut Commander,
+        change_id: Option<ChangeId>,
+        commit_id: CommitId,
+    ) -> Self {
+        Self {
+            options: generate_options(commander, change_id.as_ref()),
+            change_id,
+            list_state: ListState::default().with_selected(Some(0)),
+            list_height: 0,
+            config,
+            commit_id,
+            creating: None,
+        }
+    }
+
+    /// Render the parent into the area.
+    pub fn render(&mut self, f: &mut ratatui::prelude::Frame<'_>, area: Rect) {
+        if let Some(creating) = self.creating.as_ref() {
+            let block = Block::bordered()
+                .title(Span::styled(" Create branch ", Style::new().bold().cyan()))
+                .title_alignment(Alignment::Center)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Green));
+            let area = centered_rect_line_height(area, 30, 5);
+            f.render_widget(Clear, area);
+            f.render_widget(&block, area);
+
+            let popup_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Fill(1), Constraint::Length(2)])
+                .split(block.inner(area));
+
+            f.render_widget(creating.widget(), popup_chunks[0]);
+
+            let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
+                .fg(Color::DarkGray)
+                .alignment(Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                );
+
+            f.render_widget(help, popup_chunks[1]);
+        } else {
+            let block = Block::bordered()
+                .title(Span::styled(" Select branch ", Style::new().bold().cyan()))
+                .title_alignment(Alignment::Center)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Green));
+            let area = centered_rect(area, 40, 60);
+            f.render_widget(Clear, area);
+            f.render_widget(&block, area);
+
+            let popup_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Fill(1), Constraint::Length(2)])
+                .split(block.inner(area));
+
+            let list_items = self.options.iter().map(|option| match option {
+                BranchSetOption::CreateBranch => Text::raw("(C)reate branch").fg(Color::Yellow),
+                BranchSetOption::GeneratedName(generated_name, exists) => {
+                    let mut text = format!("(G)enerate branch: {}", generated_name);
+                    if *exists {
+                        text.push_str(" (exists)");
+                    }
+                    Text::raw(text).fg(Color::Yellow)
+                }
+                BranchSetOption::Branch(branch) => Text::raw(branch.to_string()).fg(Color::Magenta),
+                BranchSetOption::Error(err) => err.into_text().unwrap(),
+            });
+
+            let list = List::new(list_items)
+                .scroll_padding(3)
+                .highlight_style(Style::default().bg(self.config.highlight_color()));
+
+            f.render_stateful_widget(list, popup_chunks[0], &mut self.list_state);
+            self.list_height = popup_chunks[0].height;
+
+            let help = Paragraph::new(vec!["j/k: scroll down/up | Escape: cancel".into()])
+                .fg(Color::DarkGray)
+                .alignment(Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                );
+
+            f.render_widget(help, popup_chunks[1]);
+        }
+    }
+
+    fn scroll(&mut self, scroll: isize) {
+        self.list_state.select(Some(
+            self.list_state
+                .selected()
+                .map(|selected| selected.saturating_add_signed(scroll))
+                .unwrap_or(0)
+                .min(self.options.len().saturating_sub(1)),
+        ));
+    }
+
+    fn on_creating(&mut self) {
+        self.creating = Some(TextArea::default());
+    }
+
+    fn create_branch(&self, commander: &mut Commander, name: &str) -> Result<()> {
+        if commander
+            .get_branches_list(false)?
+            .iter()
+            .any(|branch| branch.name == name)
+        {
+            commander.set_branch_commit(name, &self.commit_id)?;
+        } else {
+            commander.create_branch_commit(name, &self.commit_id)?;
+        }
+        Ok(())
+    }
+    fn generate_branch(&self, commander: &mut Commander) -> Result<()> {
+        if let Some(change_id) = self.change_id.as_ref() {
+            let generated_name = generate_name(&commander.env.config.branch_prefix(), change_id);
+            if commander
+                .get_branches_list(false)?
+                .iter()
+                .any(|branch| branch.name == generated_name)
+            {
+                commander.set_branch_commit(&generated_name, &self.commit_id)?;
+            } else {
+                commander.create_branch_commit(&generated_name, &self.commit_id)?;
+            }
+            Ok(())
+        } else {
+            bail!("No change ID");
+        }
+    }
+
+    /// Handle input. Returns bool of if to close
+    pub fn input(&mut self, event: Event, commander: &mut Commander) -> Result<bool> {
+        if let Some(creating) = self.creating.as_mut() {
+            if let Event::Key(key) = event {
+                match key.code {
+                    _ if (key.code == KeyCode::Char('s')
+                        && key.modifiers.contains(KeyModifiers::CONTROL))
+                        || (key.code == KeyCode::Enter) =>
+                    {
+                        let name = &creating.lines().join("\n");
+                        if name.trim().is_empty() {
+                            return Ok(false);
+                        }
+
+                        self.create_branch(commander, name)?;
+                        return Ok(true);
+                    }
+                    KeyCode::Esc => {
+                        return Ok(true);
+                    }
+                    _ => {}
+                }
+            }
+            creating.input(event);
+            return Ok(false);
+        }
+
+        if let Event::Key(key) = event {
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.scroll(1);
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.scroll(-1);
+                }
+                KeyCode::Char('J') => {
+                    self.scroll(self.list_height as isize / 2);
+                }
+                KeyCode::Char('K') => {
+                    self.scroll((self.list_height as isize / 2).saturating_neg());
+                }
+                KeyCode::Char('g') => {
+                    self.generate_branch(commander)?;
+                    return Ok(true);
+                }
+                KeyCode::Char('c') => {
+                    self.on_creating();
+                }
+                KeyCode::Enter => {
+                    if let Some(index) = self.list_state.selected()
+                        && let Some(action) = self.options.get(index)
+                    {
+                        match action {
+                            BranchSetOption::CreateBranch => {
+                                self.on_creating();
+                            }
+                            BranchSetOption::GeneratedName(_, _) => {
+                                self.generate_branch(commander)?;
+                                return Ok(true);
+                            }
+                            BranchSetOption::Branch(branch) => {
+                                commander.set_branch_commit(&branch.name, &self.commit_id)?;
+                                return Ok(true);
+                            }
+                            BranchSetOption::Error(_) => {
+                                self.options = generate_options(commander, self.change_id.as_ref());
+                            }
+                        }
+                    }
+                }
+                KeyCode::Char('q') | KeyCode::Esc => return Ok(true),
+                _ => {}
+            }
+        }
+
+        Ok(false)
+    }
+}

--- a/src/ui/branches.rs
+++ b/src/ui/branches.rs
@@ -1,0 +1,720 @@
+#![allow(clippy::borrow_interior_mutable_const)]
+use crate::{
+    commander::{branches::BranchLine, CommandError, Commander},
+    env::{Config, DiffFormat},
+    ui::{
+        details_panel::DetailsPanel, message_popup::MessagePopup, utils::centered_rect_line_height,
+        Component, ComponentAction,
+    },
+    ComponentInputResult,
+};
+use ansi_to_tui::IntoText;
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+use ratatui::{prelude::*, widgets::*};
+use tui_confirm_dialog::{ButtonLabel, ConfirmDialog, ConfirmDialogState, Listener};
+use tui_textarea::{CursorMove, TextArea};
+
+struct CreateBranch<'a> {
+    textarea: TextArea<'a>,
+    error: Option<anyhow::Error>,
+}
+
+struct RenameBranch<'a> {
+    textarea: TextArea<'a>,
+    name: String,
+    error: Option<anyhow::Error>,
+}
+
+struct DeleteBranch {
+    name: String,
+}
+
+const DELETE_BRANCH_POPUP_ID: u16 = 1;
+
+/// Branches tab. Shows branches in left panel and selected branch current change in right panel.
+pub struct Branches<'a> {
+    branches_output: Result<Vec<BranchLine>, CommandError>,
+    branches_list_state: ListState,
+    branches_height: u16,
+
+    show_all: bool,
+
+    branch: Option<BranchLine>,
+
+    branch_panel: DetailsPanel,
+    branch_output: Option<Result<String, CommandError>>,
+
+    create: Option<CreateBranch<'a>>,
+    rename: Option<RenameBranch<'a>>,
+    delete: Option<DeleteBranch>,
+
+    popup: ConfirmDialogState,
+    popup_tx: std::sync::mpsc::Sender<Listener>,
+    popup_rx: std::sync::mpsc::Receiver<Listener>,
+
+    message_popup: Option<MessagePopup<'a>>,
+
+    diff_format: DiffFormat,
+
+    config: Config,
+}
+
+fn get_current_branch_index(
+    current_branch: Option<&BranchLine>,
+    branches_output: &Result<Vec<BranchLine>, CommandError>,
+) -> Option<usize> {
+    match branches_output {
+        Ok(branches_output) => current_branch.as_ref().and_then(|current_branch| {
+            branches_output
+                .iter()
+                .position(|branch| match (current_branch, branch) {
+                    (
+                        BranchLine::Parsed {
+                            branch: current_branch,
+                            ..
+                        },
+                        BranchLine::Parsed { branch, .. },
+                    ) => {
+                        current_branch.name == branch.name && current_branch.remote == branch.remote
+                    }
+                    (BranchLine::Unparsable(current_branch), BranchLine::Unparsable(branch)) => {
+                        current_branch == branch
+                    }
+                    _ => false,
+                })
+        }),
+        Err(_) => None,
+    }
+}
+
+impl Branches<'_> {
+    pub fn new(commander: &mut Commander) -> Result<Self> {
+        let diff_format = commander.env.config.diff_format();
+
+        let show_all = false;
+
+        let branches_output = commander.get_branches(show_all);
+        let branch = branches_output
+            .as_ref()
+            .ok()
+            .and_then(|branches_output| branches_output.first())
+            .map(|branches_output| branches_output.to_owned());
+
+        let branches_list_state = ListState::default()
+            .with_selected(get_current_branch_index(branch.as_ref(), &branches_output));
+
+        let branch_output = branch.as_ref().and_then(|branch| match branch {
+            BranchLine::Parsed { branch, .. } => {
+                Some(commander.get_branch_show(branch, &diff_format))
+            }
+            _ => None,
+        });
+
+        let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+
+        Ok(Self {
+            branches_output,
+            branch,
+            branches_list_state,
+            branches_height: 0,
+
+            show_all,
+
+            branch_panel: DetailsPanel::new(),
+            branch_output,
+
+            create: None,
+            rename: None,
+            delete: None,
+
+            popup: ConfirmDialogState::default(),
+            popup_tx,
+            popup_rx,
+
+            message_popup: None,
+
+            diff_format,
+
+            config: commander.env.config.clone(),
+        })
+    }
+
+    // pub fn set_head(&mut self, commander: &mut Commander, head: &Head) -> Result<()> {
+    //     self.head = head.clone();
+    //     self.is_current_head = self.head == commander.get_current_head()?;
+    //
+    //     self.refresh_files(commander)?;
+    //     self.file = self
+    //         .files_output
+    //         .first()
+    //         .and_then(|change| change.path.clone());
+    //     self.refresh_diff(commander)?;
+    //
+    //     Ok(())
+    // }
+
+    pub fn get_current_branch_index(&self) -> Option<usize> {
+        get_current_branch_index(self.branch.as_ref(), &self.branches_output)
+    }
+
+    pub fn refresh_branches(&mut self, commander: &mut Commander) {
+        self.branches_output = commander.get_branches(self.show_all);
+    }
+
+    pub fn refresh_branch(&mut self, commander: &mut Commander) {
+        self.branch_output = self.branch.as_ref().and_then(|branch| match branch {
+            BranchLine::Parsed { branch, .. } => {
+                Some(commander.get_branch_show(branch, &self.diff_format))
+            }
+            _ => None,
+        });
+
+        self.branch_panel.scroll = 0;
+    }
+
+    fn scroll_branches(&mut self, commander: &mut Commander, scroll: isize) {
+        let branches = Vec::new();
+        let branches = self.branches_output.as_ref().unwrap_or(&branches);
+        let current_branch_index = self.get_current_branch_index();
+        let next_branch = match current_branch_index {
+            Some(current_branch_index) => branches.get(
+                current_branch_index
+                    .saturating_add_signed(scroll)
+                    .min(branches.len() - 1),
+            ),
+            None => branches.first(),
+        }
+        .map(|x| x.to_owned());
+
+        if let Some(next_branch) = next_branch {
+            self.branch = Some(next_branch);
+            self.refresh_branch(commander);
+        }
+    }
+}
+
+impl Component for Branches<'_> {
+    fn switch(&mut self, commander: &mut Commander) -> Result<()> {
+        self.refresh_branches(commander);
+        self.refresh_branch(commander);
+        Ok(())
+    }
+
+    fn update(&mut self, commander: &mut Commander) -> Result<Option<ComponentAction>> {
+        // Check for popup action
+        if let Ok(res) = self.popup_rx.try_recv()
+            && res.1.unwrap_or(false)
+        {
+            match res.0 {
+                DELETE_BRANCH_POPUP_ID => {
+                    if let Some(delete) = self.delete.as_ref() {
+                        match commander.delete_branch(&delete.name) {
+                            Ok(_) => {
+                                self.refresh_branches(commander);
+                                let branches = Vec::new();
+                                let branches = self.branches_output.as_ref().unwrap_or(&branches);
+                                self.branch = branches.first().map(|branch| branch.to_owned());
+                                self.refresh_branch(commander);
+                            }
+                            Err(err) => {
+                                self.message_popup = Some(MessagePopup {
+                                    title: "Delete error".into(),
+                                    messages: err.to_string().into_text()?,
+                                });
+                            }
+                        }
+                        return Ok(None);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn draw(
+        &mut self,
+        f: &mut ratatui::prelude::Frame<'_>,
+        area: ratatui::prelude::Rect,
+    ) -> Result<()> {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
+
+        // Draw branches
+        {
+            let panel_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Fill(1), Constraint::Length(2)])
+                .split(chunks[0]);
+
+            let current_branch_index = self.get_current_branch_index();
+
+            let branch_lines: Vec<Line> = match self.branches_output.as_ref() {
+                Ok(branches_output) => branches_output
+                    .iter()
+                    .enumerate()
+                    .map(|(i, branch)| -> Result<Vec<Line>, ansi_to_tui::Error> {
+                        let branch_text = branch.to_text()?;
+                        Ok(branch_text
+                            .iter()
+                            .map(|line| {
+                                let mut line = line.to_owned();
+
+                                if current_branch_index
+                                    .map_or(false, |current_branch_index| i == current_branch_index)
+                                {
+                                    line = line.bg(self.config.highlight_color());
+
+                                    line.spans = line
+                                        .spans
+                                        .iter_mut()
+                                        .map(|span| {
+                                            span.to_owned().bg(self.config.highlight_color())
+                                        })
+                                        .collect();
+                                }
+
+                                line
+                            })
+                            .collect::<Vec<Line>>())
+                    })
+                    .collect::<Result<Vec<Vec<Line>>, ansi_to_tui::Error>>()?
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                Err(err) => [
+                    vec![Line::raw("Error getting branches").bold().fg(Color::Red)],
+                    // TODO: Remove when jj 0.20 is released
+                    if let CommandError::Status(output, _) = err
+                        && output.contains("unexpected argument '-T' found")
+                    {
+                        vec![
+                            Line::raw(""),
+                            Line::raw("Please update jj to >0.18 for -T support to branches")
+                                .bold()
+                                .fg(Color::Red),
+                        ]
+                    } else {
+                        vec![]
+                    },
+                    vec![Line::raw(""), Line::raw("")],
+                    err.to_string().into_text()?.lines,
+                ]
+                .concat(),
+            };
+
+            let lines = if branch_lines.is_empty() {
+                vec![Line::from(" No branches").fg(Color::DarkGray).italic()]
+            } else {
+                branch_lines
+            };
+
+            let files = List::new(lines)
+                .block(
+                    Block::bordered()
+                        .title(" Branches ")
+                        .border_type(BorderType::Rounded),
+                )
+                .scroll_padding(3);
+            *self.branches_list_state.selected_mut() = current_branch_index;
+            f.render_stateful_widget(files, panel_chunks[0], &mut self.branches_list_state);
+            self.branches_height = panel_chunks[0].height - 2;
+
+            let help = Paragraph::new(vec![
+                "j/k: scroll down/up | J/K: scroll down by ½ page | a: show all remotes".into(),
+                "c: create branch | r: rename branch | d: delete branch".into(),
+            ])
+            .fg(Color::DarkGray);
+            f.render_widget(help, panel_chunks[1]);
+        }
+
+        // Draw branch
+        {
+            let panel_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Fill(1), Constraint::Length(2)])
+                .split(chunks[1]);
+
+            let title = if let Some(BranchLine::Parsed { branch, .. }) = self.branch.as_ref() {
+                format!(" Branch {} ", branch)
+            } else {
+                " Branch ".to_owned()
+            };
+
+            let branch_block = Block::bordered()
+                .title(title)
+                .border_type(BorderType::Rounded);
+            let branch_content: Vec<Line> = match self.branch_output.as_ref() {
+                Some(Ok(branch_output)) => branch_output.into_text()?.lines,
+                Some(Err(err)) => err.into_text("Error getting branch")?.lines,
+                None => vec![],
+            };
+            let branch = self
+                .branch_panel
+                .render(branch_content, branch_block.inner(chunks[1]))
+                .block(branch_block);
+            f.render_widget(branch, panel_chunks[0]);
+
+            let help = Paragraph::new(vec![
+                "Ctrl+e/Ctrl+y: scroll down/up | Ctrl+d/Ctrl+u: scroll down/up by ½ page".into(),
+                "Ctrl+f/Ctrl+b: scroll down/up by page | p: toggle diff format | w: toggle wrapping".into(),
+            ]).fg(Color::DarkGray);
+            f.render_widget(help, panel_chunks[1]);
+        }
+
+        // Draw popup
+        if self.popup.is_opened() {
+            let popup = ConfirmDialog::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Green))
+                .selected_button_style(
+                    Style::default()
+                        .bg(self.config.highlight_color())
+                        .underlined(),
+                );
+            f.render_stateful_widget(popup, area, &mut self.popup);
+        }
+
+        // Draw messge popup
+        if let Some(message_popup) = &self.message_popup {
+            f.render_widget(message_popup.render(), area);
+        }
+
+        // Draw create textarea
+        {
+            if let Some(create) = self.create.as_mut() {
+                let block = Block::bordered()
+                    .title(Span::styled(" Create branch ", Style::new().bold().cyan()))
+                    .title_alignment(Alignment::Center)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::Green));
+                let error_lines = create
+                    .error
+                    .as_ref()
+                    .map(|error| error.to_string().into_text().unwrap().lines);
+                let error_height = if let Some(error_lines) = error_lines.as_ref() {
+                    error_lines.len() + 1
+                } else {
+                    0
+                };
+                let area = centered_rect_line_height(area, 30, 5 + error_height as u16);
+                f.render_widget(Clear, area);
+                f.render_widget(&block, area);
+
+                let popup_chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Fill(1),
+                        Constraint::Length(error_height as u16),
+                        Constraint::Length(2),
+                    ])
+                    .split(block.inner(area));
+
+                f.render_widget(create.textarea.widget(), popup_chunks[0]);
+
+                if let Some(error_lines) = error_lines {
+                    let help = Paragraph::new(error_lines).block(
+                        Block::default()
+                            .borders(Borders::TOP)
+                            .border_type(BorderType::Rounded)
+                            .border_style(Style::default().fg(Color::DarkGray)),
+                    );
+
+                    f.render_widget(help, popup_chunks[1]);
+                }
+
+                let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
+                    .fg(Color::DarkGray)
+                    .alignment(Alignment::Center)
+                    .block(
+                        Block::default()
+                            .borders(Borders::TOP)
+                            .border_type(BorderType::Rounded)
+                            .border_style(Style::default().fg(Color::DarkGray)),
+                    );
+
+                f.render_widget(help, popup_chunks[2]);
+            }
+        }
+
+        // Draw rename textarea
+        {
+            if let Some(rename) = self.rename.as_mut() {
+                let block = Block::bordered()
+                    .title(Span::styled(" Rename branch ", Style::new().bold().cyan()))
+                    .title_alignment(Alignment::Center)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::Green));
+                let error_lines = rename
+                    .error
+                    .as_ref()
+                    .map(|error| error.to_string().into_text().unwrap().lines);
+                let error_height = if let Some(error_lines) = error_lines.as_ref() {
+                    error_lines.len() + 1
+                } else {
+                    0
+                };
+                let area = centered_rect_line_height(area, 30, 5 + error_height as u16);
+                f.render_widget(Clear, area);
+                f.render_widget(&block, area);
+
+                let popup_chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Fill(1),
+                        Constraint::Length(error_height as u16),
+                        Constraint::Length(2),
+                    ])
+                    .split(block.inner(area));
+
+                f.render_widget(rename.textarea.widget(), popup_chunks[0]);
+
+                if let Some(error_lines) = error_lines {
+                    let help = Paragraph::new(error_lines).block(
+                        Block::default()
+                            .borders(Borders::TOP)
+                            .border_type(BorderType::Rounded)
+                            .border_style(Style::default().fg(Color::DarkGray)),
+                    );
+
+                    f.render_widget(help, popup_chunks[1]);
+                }
+
+                let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
+                    .fg(Color::DarkGray)
+                    .alignment(Alignment::Center)
+                    .block(
+                        Block::default()
+                            .borders(Borders::TOP)
+                            .border_type(BorderType::Rounded)
+                            .border_style(Style::default().fg(Color::DarkGray)),
+                    );
+
+                f.render_widget(help, popup_chunks[2]);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult> {
+        if let Some(create) = self.create.as_mut() {
+            if let Event::Key(key) = event {
+                match key.code {
+                    _ if (key.code == KeyCode::Char('s')
+                        && key.modifiers.contains(KeyModifiers::CONTROL))
+                        || (key.code == KeyCode::Enter) =>
+                    {
+                        let name = create.textarea.lines().join("\n");
+
+                        if name.trim().is_empty() {
+                            create.error = Some(anyhow::Error::msg("Branch name cannot be empty"));
+                            return Ok(ComponentInputResult::Handled);
+                        }
+
+                        if let Err(err) = commander.create_branch(&name) {
+                            create.error = Some(anyhow::Error::new(err));
+                            return Ok(ComponentInputResult::Handled);
+                        }
+
+                        self.create = None;
+                        self.refresh_branches(commander);
+
+                        // Select new branch
+                        if let Some(branch) =
+                            self.branches_output
+                                .as_ref()
+                                .ok()
+                                .and_then(|branches_output| {
+                                    branches_output.iter().find(|branch| match branch {
+                                        BranchLine::Unparsable(_) => false,
+                                        BranchLine::Parsed { branch, .. } => branch.name == name,
+                                    })
+                                })
+                        {
+                            self.branch = Some(branch.clone());
+                        }
+
+                        self.refresh_branch(commander);
+
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetTextAreaActive(false),
+                        ));
+                    }
+                    KeyCode::Esc => {
+                        self.create = None;
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetTextAreaActive(false),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            create.textarea.input(event);
+            return Ok(ComponentInputResult::Handled);
+        }
+
+        if let Some(rename) = self.rename.as_mut() {
+            if let Event::Key(key) = event {
+                match key.code {
+                    _ if (key.code == KeyCode::Char('s')
+                        && key.modifiers.contains(KeyModifiers::CONTROL))
+                        || (key.code == KeyCode::Enter) =>
+                    {
+                        let new = rename.textarea.lines().join("\n");
+
+                        if new.trim().is_empty() {
+                            rename.error = Some(anyhow::Error::msg("Branch name cannot be empty"));
+                            return Ok(ComponentInputResult::Handled);
+                        }
+
+                        let old = rename.name.clone();
+
+                        if let Err(err) = commander.rename_branch(&old, &new) {
+                            rename.error = Some(anyhow::Error::new(err));
+                            return Ok(ComponentInputResult::Handled);
+                        }
+                        self.rename = None;
+                        self.refresh_branches(commander);
+
+                        // Select new branch
+                        if let Some(branch) =
+                            self.branches_output
+                                .as_ref()
+                                .ok()
+                                .and_then(|branches_output| {
+                                    branches_output.iter().find(|branch| match branch {
+                                        BranchLine::Unparsable(_) => false,
+                                        BranchLine::Parsed { branch, .. } => branch.name == new,
+                                    })
+                                })
+                        {
+                            self.branch = Some(branch.clone());
+                        }
+
+                        self.refresh_branch(commander);
+
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetTextAreaActive(false),
+                        ));
+                    }
+                    KeyCode::Esc => {
+                        self.rename = None;
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetTextAreaActive(false),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            rename.textarea.input(event);
+            return Ok(ComponentInputResult::Handled);
+        }
+
+        if let Event::Key(key) = event {
+            if self.popup.is_opened() {
+                if key.code == KeyCode::Char('q') || key.code == KeyCode::Esc {
+                    self.popup = ConfirmDialogState::default();
+                } else {
+                    self.popup.handle(key);
+                }
+
+                return Ok(ComponentInputResult::Handled);
+            }
+            if let Some(message_popup) = &self.message_popup {
+                if key.code == KeyCode::Char('q')
+                    || key.code == KeyCode::Esc
+                    || message_popup.input(key)
+                {
+                    self.message_popup = None;
+                }
+
+                return Ok(ComponentInputResult::Handled);
+            }
+
+            if self.branch_panel.input(key) {
+                return Ok(ComponentInputResult::Handled);
+            }
+
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => self.scroll_branches(commander, 1),
+                KeyCode::Char('k') | KeyCode::Up => self.scroll_branches(commander, -1),
+                KeyCode::Char('J') => {
+                    self.scroll_branches(commander, self.branches_height as isize / 2);
+                }
+                KeyCode::Char('K') => {
+                    self.scroll_branches(
+                        commander,
+                        (self.branches_height as isize / 2).saturating_neg(),
+                    );
+                }
+                KeyCode::Char('p') => {
+                    self.diff_format = match self.diff_format {
+                        DiffFormat::ColorWords => DiffFormat::Git,
+                        _ => DiffFormat::ColorWords,
+                    };
+                    self.refresh_branch(commander);
+                }
+                KeyCode::Char('R') | KeyCode::F(5) => {
+                    self.refresh_branches(commander);
+                    self.refresh_branch(commander);
+                }
+                KeyCode::Char('a') => {
+                    self.show_all = !self.show_all;
+                    self.refresh_branches(commander);
+                }
+                KeyCode::Char('c') => {
+                    let textarea = TextArea::default();
+                    self.create = Some(CreateBranch {
+                        textarea,
+                        error: None,
+                    });
+                    return Ok(ComponentInputResult::HandledAction(
+                        ComponentAction::SetTextAreaActive(true),
+                    ));
+                }
+                KeyCode::Char('r') => {
+                    if let Some(BranchLine::Parsed { branch, .. }) = self.branch.as_ref() {
+                        let mut textarea = TextArea::new(vec![branch.name.clone()]);
+                        textarea.move_cursor(CursorMove::End);
+                        self.rename = Some(RenameBranch {
+                            textarea,
+                            name: branch.name.clone(),
+                            error: None,
+                        });
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetTextAreaActive(true),
+                        ));
+                    }
+                }
+                KeyCode::Char('d') => {
+                    if let Some(BranchLine::Parsed { branch, .. }) = self.branch.as_ref() {
+                        self.delete = Some(DeleteBranch {
+                            name: branch.name.clone(),
+                        });
+                        self.popup = ConfirmDialogState::new(
+                            DELETE_BRANCH_POPUP_ID,
+                            Span::styled(" Delete ", Style::new().bold().cyan()),
+                            Text::from(vec![Line::from(format!(
+                                "Are you sure you want to delete the {} branch?",
+                                branch.name
+                            ))]),
+                        )
+                        .with_yes_button(ButtonLabel::YES.clone())
+                        .with_no_button(ButtonLabel::NO.clone())
+                        .with_listener(Some(self.popup_tx.clone()))
+                        .open();
+                    }
+                }
+                _ => return Ok(ComponentInputResult::NotHandled),
+            };
+        }
+
+        Ok(ComponentInputResult::Handled)
+    }
+}

--- a/src/ui/command_log.rs
+++ b/src/ui/command_log.rs
@@ -140,7 +140,7 @@ impl CommandLog {
 
 #[allow(clippy::invisible_characters)]
 impl Component for CommandLog {
-    fn reset(&mut self, commander: &mut Commander) -> Result<()> {
+    fn switch(&mut self, commander: &mut Commander) -> Result<()> {
         let command_history = commander.command_history.clone();
         let selected_index = command_history.first().map(|_| 0);
         self.commands_list_state.select(selected_index);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,5 @@
+pub mod branch_set_popup;
+pub mod branches;
 pub mod command_log;
 pub mod details_panel;
 pub mod files;
@@ -5,8 +7,12 @@ pub mod log;
 pub mod message_popup;
 pub mod utils;
 
+use crate::{
+    app::{App, Tab},
+    commander::{log::Head, Commander},
+    ComponentInputResult,
+};
 use anyhow::Result;
-
 use crossterm::event::Event;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -14,12 +20,6 @@ use ratatui::{
     symbols, Frame,
 };
 use ratatui::{prelude::*, widgets::*};
-
-use crate::{
-    app::{App, Tab},
-    commander::{log::Head, Commander},
-    ComponentInputResult,
-};
 
 pub enum ComponentAction {
     ViewFiles(Head),
@@ -30,7 +30,7 @@ pub enum ComponentAction {
 
 pub trait Component {
     // Called when switching to tab
-    fn reset(&mut self, _commander: &mut Commander) -> Result<()> {
+    fn switch(&mut self, _commander: &mut Commander) -> Result<()> {
         Ok(())
     }
 
@@ -56,6 +56,7 @@ impl App<'_> {
         match self.current_tab {
             Tab::Log => &mut self.log,
             Tab::Files => &mut self.files,
+            Tab::Branches => &mut self.branches,
             Tab::CommandLog => &mut self.command_log,
         }
     }


### PR DESCRIPTION
Fixed https://github.com/Cretezy/lazyjj/issues/3

- [x] Branches tab
- [x] List branches
- [x] See current branch change in side panel
- [x] Create branch (`c`)
- [x] Rename branch (`r`)
- [x] Delete branch (`d`)
- [x] Set branch (`b` on a change in "Logs" tab)
- [x] Tests
- [x] Docs

Status: Working, could be better. Waiting for 0.18 (~1 week) for release due to [branch templating](https://github.com/martinvonz/jj/commit/12b873e1eff64ed3bca9bf4d1a7547c7c0c98bfd) support.

Out of scope:
- Push branch

Notes:
- Currently, conflicted branches are shown in the list, but the list does not show the list of commits the branch points to. This is due to the way lazyjj's branch list templating is currently implemented, and could be fixed to allow selecting each of the commits.