### PR TITLE
chore: Fix macOS CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
             os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
           - build: macos-x86_64
-            os: macos-11
+            os: macos-13
             target: x86_64-apple-darwin
           - build: macos-aarch64
             os: macos-14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
           - build: macos-x86_64
-            os: macos-11
+            os: macos-13
             target: x86_64-apple-darwin
           - build: macos-aarch64
             os: macos-14
@@ -62,7 +62,7 @@ jobs:
             os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
           - build: macos-x86_64
-            os: macos-11
+            os: macos-13
             target: x86_64-apple-darwin
           - build: macos-aarch64
             os: macos-14


### PR DESCRIPTION
GitHub deprecated macos-11, migrating to macos-13