### PR TITLE
Adding workflow for winget publishing

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,36 @@
+name: WinGet submission on release
+# based off of https://raw.githubusercontent.com/microsoft/PowerToys/main/.github/workflows/package-submissions.yml
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    steps:
+      - name: Submit Cretezy.lazyjj package to Windows Package Manager Community Repository
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $wingetPackage = "Cretezy.lazyjj"
+          $gitToken = "${{ secrets.PAT_WINGET }}"
+
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/Cretezy/lazyjj/releases" 
+
+          if ($github.Length -gt 0) {
+            $targetRelease = $github[0]
+            $installer = ($targetRelease.assets | where-object name -match 'x86_64-pc-windows')[0].browser_download_url
+            $ver = $targetRelease.tag_name.Trim("v")
+
+            # getting latest wingetcreate file
+            Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+            Write-Output "wingetcreate.exe update $wingetPackage -s -v $ver -u $installer -t <TOKEN>"
+            .\wingetcreate.exe update $wingetPackage -s -v $ver -u $installer -t $gitToken
+          }
+          else {
+            Write-Error "Failed to find any releases"
+            return 1
+          }
+


### PR DESCRIPTION
I put this together and have run it as a script and it works.

1. It needs a PAT with access to public repos ([ref](https://github.com/microsoft/winget-create/blob/main/README.md#github-personal-access-token-classic-permissions)
1. In the workflow I named this `PAT_WINGET` but rename it to whatever you want.
1. I *think* it wants you to have a fork of [winget-pkgs](https://github.com/microsoft/winget-pkgs) - but I couldn't find a supporting doc, but read it in a comment somewhere.  I already had it forked, so maybe try it without first to see if it needs it or not.

When run, it will open a PR on the winget-pkgs repo for the version update of `Cretezy.lazyjj` in your name.  Since we have had problems with this passing, you may need to watch the open PRs to make sure the eventually pass.