### PR TITLE
feat: Command popup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,8 +2,8 @@ use crate::{
     commander::Commander,
     env::Env,
     ui::{
-        bookmarks_tab::BookmarksTab, command_log_tab::CommandLogTab, files_tab::FilesTab,
-        log_tab::LogTab, Component, ComponentAction,
+        bookmarks_tab::BookmarksTab, command_log_tab::CommandLogTab, command_popup::CommandPopup,
+        files_tab::FilesTab, log_tab::LogTab, Component, ComponentAction,
     },
     ComponentInputResult,
 };
@@ -250,6 +250,10 @@ impl<'a> App<'a> {
                                     )
                             }) {
                                 self.set_tab(commander, *tab)?;
+                            }
+                            // General jj command runner
+                            if key.code == KeyCode::Char(':') {
+                                self.popup = Some(Box::new(CommandPopup::new()));
                             }
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -189,6 +189,25 @@ impl<'a> App<'a> {
                     self.handle_action(component_action, commander)?;
                 }
             }
+            ComponentAction::RefreshTab() => {
+                self.set_tab(commander, self.current_tab)?;
+                match self.current_tab {
+                    Tab::Log => {
+                        let head = commander.get_current_head()?;
+                        self.get_log_tab(commander)?.set_head(commander, head);
+                    }
+                    Tab::Files => {
+                        self.get_files_tab(commander)?.refresh_files(commander)?;
+                    }
+                    Tab::Bookmarks => {
+                        self.get_bookmarks_tab(commander)?
+                            .refresh_bookmark(commander);
+                    }
+                    Tab::CommandLog => {
+                        self.get_command_log_tab(commander)?.update(commander)?;
+                    }
+                };
+            }
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -196,16 +196,11 @@ impl<'a> App<'a> {
                         let head = commander.get_current_head()?;
                         self.get_log_tab(commander)?.set_head(commander, head);
                     }
-                    Tab::Files => {
-                        self.get_files_tab(commander)?.refresh_files(commander)?;
-                    }
-                    Tab::Bookmarks => {
-                        self.get_bookmarks_tab(commander)?
-                            .refresh_bookmark(commander);
-                    }
                     Tab::CommandLog => {
                         self.get_command_log_tab(commander)?.update(commander)?;
                     }
+                    _ => {}
+
                 };
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn run_app<B: Backend>(
 
                     Ok(())
                 })
-                .unwrap();
+                .unwrap_or(());
 
             let draw_span = trace_span!("draw");
             draw_span

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -235,6 +235,7 @@ impl Component for BookmarksTab<'_> {
                                         MessagePopup {
                                             title: "Delete error".into(),
                                             messages: err.to_string().into_text()?,
+                                            text_align: None,
                                         },
                                     )))));
                                 }
@@ -258,6 +259,7 @@ impl Component for BookmarksTab<'_> {
                                         MessagePopup {
                                             title: "Forget error".into(),
                                             messages: err.to_string().into_text()?,
+                                            text_align: None,
                                         },
                                     )))));
                                 }
@@ -875,6 +877,7 @@ impl Component for BookmarksTab<'_> {
                                                 .into(),
                                         ]
                                         .into(),
+                                        text_align: None,
                                     }))),
                                 ));
                             } else {

--- a/src/ui/command_popup.rs
+++ b/src/ui/command_popup.rs
@@ -85,16 +85,22 @@ impl Component for CommandPopup<'_> {
 
                     if message.trim().is_empty() {
                         return Ok(ComponentInputResult::HandledAction(
-                            ComponentAction::SetPopup(None),
+                            ComponentAction::Multiple(vec![
+                                ComponentAction::SetPopup(None),
+                                ComponentAction::RefreshTab(),
+                            ]),
                         ));
                     }
 
                     return Ok(ComponentInputResult::HandledAction(
-                        ComponentAction::SetPopup(Some(Box::new(MessagePopup {
-                            title: format!("jj {}", command_input).into(),
-                            messages: message.into(),
-                            text_align: Alignment::Left.into(),
-                        }))),
+                        ComponentAction::Multiple(vec![
+                            ComponentAction::SetPopup(Some(Box::new(MessagePopup {
+                                title: format!("jj {}", command_input).into(),
+                                messages: message.into(),
+                                text_align: Alignment::Left.into(),
+                            }))),
+                            ComponentAction::RefreshTab(),
+                        ]),
                     ));
                 }
                 KeyCode::Esc => {

--- a/src/ui/command_popup.rs
+++ b/src/ui/command_popup.rs
@@ -38,7 +38,7 @@ impl Component for CommandPopup<'_> {
             .title_alignment(Alignment::Center)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Green));
-        let area = centered_rect_line_height(area, 30, 7);
+        let area = centered_rect_line_height(area, 60, 5);
         f.render_widget(Clear, area);
         f.render_widget(&block, area);
 

--- a/src/ui/command_popup.rs
+++ b/src/ui/command_popup.rs
@@ -1,0 +1,111 @@
+use crossterm::event::{Event, KeyCode};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Style, Stylize},
+    text::Span,
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+};
+use tui_textarea::TextArea;
+
+use crate::{
+    commander::Commander,
+    ui::{
+        message_popup::MessagePopup, utils::centered_rect_line_height, Component, ComponentAction,
+    },
+    ComponentInputResult,
+};
+
+pub struct CommandPopup<'a> {
+    command_textarea: TextArea<'a>,
+}
+
+impl CommandPopup<'_> {
+    pub fn new() -> Self {
+        Self {
+            command_textarea: TextArea::new(vec![]),
+        }
+    }
+}
+
+impl Component for CommandPopup<'_> {
+    fn draw(
+        &mut self,
+        f: &mut ratatui::Frame<'_>,
+        area: ratatui::prelude::Rect,
+    ) -> anyhow::Result<()> {
+        let block = Block::bordered()
+            .title(Span::styled(" Command ", Style::new().bold().cyan()))
+            .title_alignment(Alignment::Center)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Green));
+        let area = centered_rect_line_height(area, 30, 7);
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let popup_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .split(block.inner(area));
+
+        f.render_widget(&self.command_textarea, popup_chunks[0]);
+
+        let help = Paragraph::new(vec!["Enter: run | Escape: cancel".into()])
+            .fg(Color::DarkGray)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            );
+
+        f.render_widget(help, popup_chunks[1]);
+        Ok(())
+    }
+
+    fn input(
+        &mut self,
+        commander: &mut Commander,
+        event: crossterm::event::Event,
+    ) -> anyhow::Result<ComponentInputResult> {
+        if let Event::Key(key) = event {
+            match key.code {
+                KeyCode::Enter => {
+                    let command_input = self.command_textarea.lines().join(" ");
+                    let command = command_input.split_whitespace().collect::<Vec<&str>>();
+                    let res = commander.execute_jj_command(command, false, false);
+                    let message = match res {
+                        Ok(str) => str,
+                        Err(err) => [
+                            format!("Failed to execute jj command: jj {}", command_input,),
+                            err.to_string(),
+                        ]
+                        .join("\n"),
+                    };
+
+                    if message.trim().is_empty() {
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetPopup(None),
+                        ));
+                    }
+
+                    return Ok(ComponentInputResult::HandledAction(
+                        ComponentAction::SetPopup(Some(Box::new(MessagePopup {
+                            title: format!("jj {}", command_input).into(),
+                            messages: message.into(),
+                            text_align: Alignment::Left.into(),
+                        }))),
+                    ));
+                }
+                KeyCode::Esc => {
+                    return Ok(ComponentInputResult::HandledAction(
+                        ComponentAction::SetPopup(None),
+                    ));
+                }
+                _ => {}
+            }
+        };
+        self.command_textarea.input(event);
+        Ok(ComponentInputResult::Handled)
+    }
+}

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -547,6 +547,7 @@ impl Component for LogTab<'_> {
                                     "The change cannot be edited because it is immutable.".into(),
                                 ]
                                 .into(),
+                                text_align: None,
                             }))),
                         ));
                     } else {
@@ -574,6 +575,7 @@ impl Component for LogTab<'_> {
                                         .into(),
                                 ]
                                 .into(),
+                                text_align: None,
                             }))),
                         ));
                     } else {
@@ -601,6 +603,7 @@ impl Component for LogTab<'_> {
                                         .into(),
                                 ]
                                 .into(),
+                                text_align: None,
                             }))),
                         ));
                     } else {
@@ -652,6 +655,7 @@ impl Component for LogTab<'_> {
                                 ComponentAction::SetPopup(Some(Box::new(MessagePopup {
                                     title: "Push message".into(),
                                     messages: result.into_text()?,
+                                    text_align: None,
                                 }))),
                             ));
                         }
@@ -660,6 +664,7 @@ impl Component for LogTab<'_> {
                                 ComponentAction::SetPopup(Some(Box::new(MessagePopup {
                                     title: "Push error".into(),
                                     messages: err.into_text("")?,
+                                    text_align: None,
                                 }))),
                             ));
                         }
@@ -676,6 +681,7 @@ impl Component for LogTab<'_> {
                                 ComponentAction::SetPopup(Some(Box::new(MessagePopup {
                                     title: "Fetch message".into(),
                                     messages: result.into_text()?,
+                                    text_align: None,
                                 }))),
                             ));
                         }
@@ -684,6 +690,7 @@ impl Component for LogTab<'_> {
                                 ComponentAction::SetPopup(Some(Box::new(MessagePopup {
                                     title: "Fetch error".into(),
                                     messages: err.into_text("")?,
+                                    text_align: None,
                                 }))),
                             ));
                         }

--- a/src/ui/message_popup.rs
+++ b/src/ui/message_popup.rs
@@ -14,6 +14,7 @@ use crate::{commander::Commander, ui::Component, ComponentInputResult};
 pub struct MessagePopup<'a> {
     pub title: Title<'a>,
     pub messages: Text<'a>,
+    pub text_align: Option<Alignment>,
 }
 
 impl Component for MessagePopup<'_> {
@@ -29,9 +30,14 @@ impl Component for MessagePopup<'_> {
 
         title.content = title.content.fg(Color::Cyan).bold();
 
+        let text_align = match self.text_align {
+            Some(align) => align,
+            None => Alignment::Center,
+        };
+
         let popup = PopupMessage::new(title, self.messages.clone())
             .title_alignment(Alignment::Center)
-            .text_alignment(Alignment::Center)
+            .text_alignment(text_align)
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Green));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -31,6 +31,7 @@ pub enum ComponentAction {
     ChangeHead(Head),
     SetPopup(Option<Box<dyn Component>>),
     Multiple(Vec<ComponentAction>),
+    RefreshTab(),
 }
 
 pub trait Component {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod bookmark_set_popup;
 pub mod bookmarks_tab;
 pub mod command_log_tab;
+pub mod command_popup;
 pub mod details_panel;
 pub mod files_tab;
 pub mod help_popup;


### PR DESCRIPTION
- Added a new field to MessagePopup called `text_align` for text alignment which defaults to Center.
  - Updated all references to pass None for message popup.
- Added a new popup called `CommandPopup` which is activated when `:` is pressed from any of the tabs.
  - The popup provides a TextArea which allows the user to run a jj command
    e.g. when `help` is typed, it will run `jj help`
  - Enter to confirm and execute the command
  - Esc to close the popup
- Commands with output or an error message will show it in a message popup using the left align
- Commands without output close the textarea and return to the view before running command popup (if they fail, they still show the error message) 
- New action to refresh the current tab which is called after running a command 

Open to design feedback, first time writing _any_ Rust, so please bear with me if I've made some mistakes.

asciinema showing a brief demo of the PR: https://asciinema.org/a/wFns1WU24IicaUdgh1G3RmOgR
