### PR TITLE
Add vertical layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ See all key mappings for the current tab with `h` or `?`.
 
 - Quit with `q`
 - Change tab with `1`/`2`/`3`
-- Scrolling in left panel
+- Scrolling in main panel
   - Scroll down/up by one line with `j`/`k` or down/up arrow
   - Scroll down/up by half page with `J`/`K` or down/up arrow
-- Scrolling in right panel
+- Scrolling in details panel
   - Scroll down/up by one line with `Ctrl+e`/`Ctrl+y`
   - Scroll down/up by a half page with `Ctrl+d`/`Ctrl+u`
   - Scroll down/up by a full page with `Ctrl+f`/`Ctrl+b`
@@ -81,8 +81,8 @@ See all key mappings for the current tab with `h` or `?`.
 - Select current change with `@`
 - View change files in files tab with `Enter`
 - Display different revset with `r` (`jj log -r`)
-- Change right panel diff format between color words (default) and Git with `w`
-- Toggle right panel wrapping with `W`
+- Change details panel diff format between color words (default) and Git with `w`
+- Toggle details panel wrapping with `W`
 - Create new change after highlighted change with `n` (`jj new`)
   - Create new change and describe with `N` (`jj new -m`)
 - Edit highlighted change `e` (`jj edit`)
@@ -102,8 +102,8 @@ See all key mappings for the current tab with `h` or `?`.
 ### Files tab
 
 - Select current change with `@`
-- Change right panel diff format between color words (default) and Git with `w`
-- Toggle right panel wrapping with `W`
+- Change details panel diff format between color words (default) and Git with `w`
+- Toggle details panel wrapping with `W`
 
 ### Bookmarks tab
 
@@ -114,15 +114,15 @@ See all key mappings for the current tab with `h` or `?`.
 - Forget a bookmark with `f` (`jj bookmark forget`)
 - Track a bookmark with `t` (only works for bookmarks with remotes) (`jj bookmark track`)
 - Untrack a bookmark with `T` (only works for bookmarks with remotes) (`jj bookmark untrack`)
-- Change right panel diff format between color words (default) and Git with `w`
-- Toggle right panel wrapping with `W`
+- Change details panel diff format between color words (default) and Git with `w`
+- Toggle details panel wrapping with `W`
 - Create a new change after the highlighted bookmark's change with `n` (`jj new`)
   - Create a new change and describe with `N` (`jj new -m`)
 
 ### Command log tab
 
 - Select latest command with `@`
-- Toggle right panel wrapping with `W`
+- Toggle details panel wrapping with `W`
 
 ## Development
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -17,6 +17,8 @@ pub struct Config {
     lazyjj_bookmark_prefix: Option<String>,
     #[serde(rename = "lazyjj.layout")]
     lazyjj_layout: Option<JJLayout>,
+    #[serde(rename = "lazyjj.layout-percent")]
+    lazyjj_layout_percent: Option<u16>,
     #[serde(rename = "ui.diff.format")]
     ui_diff_format: Option<DiffFormat>,
     #[serde(rename = "git.push-bookmark-prefix")]
@@ -38,6 +40,7 @@ pub struct JjConfigLazyjj {
     diff_format: Option<DiffFormat>,
     bookmark_prefix: Option<String>,
     layout: Option<JJLayout>,
+    layout_percent: Option<u16>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -79,6 +82,10 @@ impl Config {
 
     pub fn layout(&self) -> JJLayout {
         self.lazyjj_layout.unwrap_or(JJLayout::Horizontal)
+    }
+
+    pub fn layout_percent(&self) -> u16 {
+        self.lazyjj_layout_percent.unwrap_or(50)
     }
 }
 
@@ -148,6 +155,10 @@ impl Env {
                             .lazyjj
                             .as_ref()
                             .and_then(|lazyjj| lazyjj.layout),
+                        lazyjj_layout_percent: config
+                            .lazyjj
+                            .as_ref()
+                            .and_then(|lazyjj| lazyjj.layout_percent),
                         ui_diff_format: config
                             .ui
                             .and_then(|ui| ui.diff.and_then(|diff| diff.format)),

--- a/src/env.rs
+++ b/src/env.rs
@@ -151,10 +151,7 @@ impl Env {
                             .lazyjj
                             .as_ref()
                             .and_then(|lazyjj| lazyjj.bookmark_prefix.clone()),
-                        lazyjj_layout: config
-                            .lazyjj
-                            .as_ref()
-                            .and_then(|lazyjj| lazyjj.layout),
+                        lazyjj_layout: config.lazyjj.as_ref().and_then(|lazyjj| lazyjj.layout),
                         lazyjj_layout_percent: config
                             .lazyjj
                             .as_ref()
@@ -193,4 +190,14 @@ pub enum JJLayout {
     #[default]
     Horizontal,
     Vertical,
+}
+
+// Impl into for JJLayout to ratatui's Direction
+impl From<JJLayout> for ratatui::layout::Direction {
+    fn from(layout: JJLayout) -> Self {
+        match layout {
+            JJLayout::Horizontal => ratatui::layout::Direction::Horizontal,
+            JJLayout::Vertical => ratatui::layout::Direction::Vertical,
+        }
+    }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -15,6 +15,8 @@ pub struct Config {
     lazyjj_diff_format: Option<DiffFormat>,
     #[serde(rename = "lazyjj.bookmark-prefix")]
     lazyjj_bookmark_prefix: Option<String>,
+    #[serde(rename = "lazyjj.layout")]
+    lazyjj_layout: Option<JJLayout>,
     #[serde(rename = "ui.diff.format")]
     ui_diff_format: Option<DiffFormat>,
     #[serde(rename = "git.push-bookmark-prefix")]
@@ -35,6 +37,7 @@ pub struct JjConfigLazyjj {
     highlight_color: Option<Color>,
     diff_format: Option<DiffFormat>,
     bookmark_prefix: Option<String>,
+    layout: Option<JJLayout>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -72,6 +75,10 @@ impl Config {
                 .clone()
                 .unwrap_or("push-".to_owned()),
         )
+    }
+
+    pub fn layout(&self) -> JJLayout {
+        self.lazyjj_layout.unwrap_or(JJLayout::Horizontal)
     }
 }
 
@@ -137,6 +144,10 @@ impl Env {
                             .lazyjj
                             .as_ref()
                             .and_then(|lazyjj| lazyjj.bookmark_prefix.clone()),
+                        lazyjj_layout: config
+                            .lazyjj
+                            .as_ref()
+                            .and_then(|lazyjj| lazyjj.layout),
                         ui_diff_format: config
                             .ui
                             .and_then(|ui| ui.diff.and_then(|diff| diff.format)),
@@ -163,4 +174,12 @@ pub enum DiffFormat {
     Git,
     Summary,
     Stat,
+}
+
+#[derive(Clone, Debug, Deserialize, Default, Copy, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum JJLayout {
+    #[default]
+    Horizontal,
+    Vertical,
 }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -71,6 +71,7 @@ pub struct BookmarksTab<'a> {
 
     diff_format: DiffFormat,
     layout_direction: Direction,
+    layout_percent: u16,
 
     config: Config,
 }
@@ -140,6 +141,8 @@ impl BookmarksTab<'_> {
         } else {
             Direction::Vertical
         };
+        let layout_percent = commander.env.config.layout_percent();
+
         Ok(Self {
             bookmarks_output,
             bookmark,
@@ -166,6 +169,7 @@ impl BookmarksTab<'_> {
 
             diff_format,
             layout_direction,
+            layout_percent,
 
             config: commander.env.config.clone(),
         })
@@ -310,7 +314,10 @@ impl Component for BookmarksTab<'_> {
     ) -> Result<()> {
         let chunks = Layout::default()
             .direction(self.layout_direction)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints([
+                Constraint::Percentage(self.layout_percent),
+                Constraint::Percentage(100 - self.layout_percent),
+            ])
             .split(area);
 
         // Draw bookmarks

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::borrow_interior_mutable_const)]
 use crate::{
     commander::{bookmarks::BookmarkLine, ids::ChangeId, CommandError, Commander},
-    env::{Config, DiffFormat, JJLayout},
+    env::{Config, DiffFormat},
     ui::{
         details_panel::DetailsPanel,
         help_popup::HelpPopup,
@@ -70,8 +70,6 @@ pub struct BookmarksTab<'a> {
     popup_rx: std::sync::mpsc::Receiver<Listener>,
 
     diff_format: DiffFormat,
-    layout_direction: Direction,
-    layout_percent: u16,
 
     config: Config,
 }
@@ -136,13 +134,6 @@ impl BookmarksTab<'_> {
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
 
-        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
-            Direction::Horizontal
-        } else {
-            Direction::Vertical
-        };
-        let layout_percent = commander.env.config.layout_percent();
-
         Ok(Self {
             bookmarks_output,
             bookmark,
@@ -168,8 +159,6 @@ impl BookmarksTab<'_> {
             popup_rx,
 
             diff_format,
-            layout_direction,
-            layout_percent,
 
             config: commander.env.config.clone(),
         })
@@ -313,10 +302,10 @@ impl Component for BookmarksTab<'_> {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(self.layout_direction)
+            .direction(self.config.layout().into())
             .constraints([
-                Constraint::Percentage(self.layout_percent),
-                Constraint::Percentage(100 - self.layout_percent),
+                Constraint::Percentage(self.config.layout_percent()),
+                Constraint::Percentage(100 - self.config.layout_percent()),
             ])
             .split(area);
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::borrow_interior_mutable_const)]
 use crate::{
     commander::{bookmarks::BookmarkLine, ids::ChangeId, CommandError, Commander},
-    env::{Config, DiffFormat},
+    env::{Config, DiffFormat, JJLayout},
     ui::{
         details_panel::DetailsPanel,
         help_popup::HelpPopup,
@@ -70,6 +70,7 @@ pub struct BookmarksTab<'a> {
     popup_rx: std::sync::mpsc::Receiver<Listener>,
 
     diff_format: DiffFormat,
+    layout_direction: Direction,
 
     config: Config,
 }
@@ -134,6 +135,11 @@ impl BookmarksTab<'_> {
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
 
+        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
+            Direction::Horizontal
+        } else {
+            Direction::Vertical
+        };
         Ok(Self {
             bookmarks_output,
             bookmark,
@@ -159,6 +165,7 @@ impl BookmarksTab<'_> {
             popup_rx,
 
             diff_format,
+            layout_direction,
 
             config: commander.env.config.clone(),
         })
@@ -302,7 +309,7 @@ impl Component for BookmarksTab<'_> {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(Direction::Horizontal)
+            .direction(self.layout_direction)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -43,7 +43,7 @@ const FORGET_BRANCH_POPUP_ID: u16 = 2;
 const NEW_POPUP_ID: u16 = 3;
 const EDIT_POPUP_ID: u16 = 4;
 
-/// Bookmarks tab. Shows bookmarks in left panel and selected bookmark current change in right panel.
+/// Bookmarks tab. Shows bookmarks in main panel and selected bookmark current change in details panel.
 pub struct BookmarksTab<'a> {
     bookmarks_output: Result<Vec<BookmarkLine>, CommandError>,
     bookmarks_list_state: ListState,

--- a/src/ui/command_log_tab.rs
+++ b/src/ui/command_log_tab.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use crate::{
     commander::{CommandLogItem, Commander},
-    env::{Config, JJLayout},
+    env::Config,
     ui::{
         details_panel::DetailsPanel, help_popup::HelpPopup, utils::tabs_to_spaces, Component,
         ComponentAction,
@@ -24,9 +24,6 @@ pub struct CommandLogTab {
     commands_list_state: ListState,
     commands_height: u16,
 
-    layout_direction: Direction,
-    layout_percent: u16,
-
     output_panel: DetailsPanel,
 
     config: Config,
@@ -39,19 +36,10 @@ impl CommandLogTab {
         let selected_index = command_history.first().map(|_| 0);
         let commands_list_state = ListState::default().with_selected(selected_index);
 
-        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
-            Direction::Horizontal
-        } else {
-            Direction::Vertical
-        };
-        let layout_percent = commander.env.config.layout_percent();
-
         Ok(Self {
             commands_height: 0,
             commands_list_state,
             command_history,
-            layout_direction,
-            layout_percent,
             output_panel: DetailsPanel::new(),
             config: commander.env.config.clone(),
         })
@@ -107,8 +95,7 @@ impl CommandLogTab {
                             Line::default().spans([Span::raw("Output:").fg(Color::Green).bold()]),
                         );
                         output_lines.push(Line::default());
-                        output_lines
-                            .append(&mut tabs_to_spaces(&stdout.to_string()).into_text()?.lines);
+                        output_lines.append(&mut tabs_to_spaces(stdout).into_text()?.lines);
                         has_output = true;
                     }
 
@@ -174,10 +161,10 @@ impl Component for CommandLogTab {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(self.layout_direction)
+            .direction(self.config.layout().into())
             .constraints([
-                Constraint::Percentage(self.layout_percent),
-                Constraint::Percentage(100 - self.layout_percent),
+                Constraint::Percentage(self.config.layout_percent()),
+                Constraint::Percentage(100 - self.config.layout_percent()),
             ])
             .split(area);
 

--- a/src/ui/command_log_tab.rs
+++ b/src/ui/command_log_tab.rs
@@ -17,8 +17,8 @@ use crate::{
     ComponentInputResult,
 };
 
-/// Command log tab. Shows list of commands exectured by lazyjj in left panel and selected command
-/// output in right panel
+/// Command log tab. Shows list of commands exectured by lazyjj in main panel and selected command
+/// output in details panel
 pub struct CommandLogTab {
     command_history: Vec<CommandLogItem>,
     commands_list_state: ListState,

--- a/src/ui/command_log_tab.rs
+++ b/src/ui/command_log_tab.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use crate::{
     commander::{CommandLogItem, Commander},
-    env::Config,
+    env::{Config, JJLayout},
     ui::{
         details_panel::DetailsPanel, help_popup::HelpPopup, utils::tabs_to_spaces, Component,
         ComponentAction,
@@ -24,6 +24,8 @@ pub struct CommandLogTab {
     commands_list_state: ListState,
     commands_height: u16,
 
+    layout_direction: Direction,
+
     output_panel: DetailsPanel,
 
     config: Config,
@@ -36,10 +38,17 @@ impl CommandLogTab {
         let selected_index = command_history.first().map(|_| 0);
         let commands_list_state = ListState::default().with_selected(selected_index);
 
+        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
+            Direction::Horizontal
+        } else {
+            Direction::Vertical
+        };
+
         Ok(Self {
             commands_height: 0,
             commands_list_state,
             command_history,
+            layout_direction,
             output_panel: DetailsPanel::new(),
             config: commander.env.config.clone(),
         })
@@ -162,7 +171,7 @@ impl Component for CommandLogTab {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(Direction::Horizontal)
+            .direction(self.layout_direction)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 

--- a/src/ui/command_log_tab.rs
+++ b/src/ui/command_log_tab.rs
@@ -25,6 +25,7 @@ pub struct CommandLogTab {
     commands_height: u16,
 
     layout_direction: Direction,
+    layout_percent: u16,
 
     output_panel: DetailsPanel,
 
@@ -43,12 +44,14 @@ impl CommandLogTab {
         } else {
             Direction::Vertical
         };
+        let layout_percent = commander.env.config.layout_percent();
 
         Ok(Self {
             commands_height: 0,
             commands_list_state,
             command_history,
             layout_direction,
+            layout_percent,
             output_panel: DetailsPanel::new(),
             config: commander.env.config.clone(),
         })
@@ -172,7 +175,10 @@ impl Component for CommandLogTab {
     ) -> Result<()> {
         let chunks = Layout::default()
             .direction(self.layout_direction)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints([
+                Constraint::Percentage(self.layout_percent),
+                Constraint::Percentage(100 - self.layout_percent),
+            ])
             .split(area);
 
         // Draw commands

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -7,7 +7,7 @@ use crate::{
         log::Head,
         CommandError, Commander,
     },
-    env::{Config, DiffFormat, JJLayout},
+    env::{Config, DiffFormat},
     ui::{
         details_panel::DetailsPanel, help_popup::HelpPopup, utils::tabs_to_spaces, Component,
         ComponentAction,
@@ -33,8 +33,6 @@ pub struct FilesTab {
     diff_panel: DetailsPanel,
     diff_output: Result<Option<String>, CommandError>,
     diff_format: DiffFormat,
-    layout_direction: Direction,
-    layout_percent: u16,
 
     config: Config,
 }
@@ -73,13 +71,6 @@ impl FilesTab {
             .map(|current_change| commander.get_file_diff(&head, current_change, &diff_format))
             .map_or(Ok(None), |r| r.map(|diff| Some(tabs_to_spaces(&diff))));
 
-        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
-            Direction::Horizontal
-        } else {
-            Direction::Vertical
-        };
-        let layout_percent = commander.env.config.layout_percent();
-
         let files_list_state = ListState::default().with_selected(get_current_file_index(
             current_file.as_ref(),
             files_output.as_ref(),
@@ -99,8 +90,6 @@ impl FilesTab {
             diff_output,
             diff_format,
             diff_panel: DetailsPanel::new(),
-            layout_direction,
-            layout_percent,
 
             config: commander.env.config.clone(),
         })
@@ -179,10 +168,10 @@ impl Component for FilesTab {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(self.layout_direction)
+            .direction(self.config.layout().into())
             .constraints([
-                Constraint::Percentage(self.layout_percent),
-                Constraint::Percentage(100 - self.layout_percent),
+                Constraint::Percentage(self.config.layout_percent()),
+                Constraint::Percentage(100 - self.config.layout_percent()),
             ])
             .split(area);
 

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -34,6 +34,7 @@ pub struct FilesTab {
     diff_output: Result<Option<String>, CommandError>,
     diff_format: DiffFormat,
     layout_direction: Direction,
+    layout_percent: u16,
 
     config: Config,
 }
@@ -73,10 +74,11 @@ impl FilesTab {
             .map_or(Ok(None), |r| r.map(|diff| Some(tabs_to_spaces(&diff))));
 
         let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
-          Direction::Horizontal
+            Direction::Horizontal
         } else {
-          Direction::Vertical
+            Direction::Vertical
         };
+        let layout_percent = commander.env.config.layout_percent();
 
         let files_list_state = ListState::default().with_selected(get_current_file_index(
             current_file.as_ref(),
@@ -98,6 +100,7 @@ impl FilesTab {
             diff_format,
             diff_panel: DetailsPanel::new(),
             layout_direction,
+            layout_percent,
 
             config: commander.env.config.clone(),
         })
@@ -177,7 +180,10 @@ impl Component for FilesTab {
     ) -> Result<()> {
         let chunks = Layout::default()
             .direction(self.layout_direction)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints([
+                Constraint::Percentage(self.layout_percent),
+                Constraint::Percentage(100 - self.layout_percent),
+            ])
             .split(area);
 
         // Draw files

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -19,7 +19,7 @@ use ansi_to_tui::IntoText;
 use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::{prelude::*, widgets::*};
 
-/// Files tab. Shows files in selected change in left panel and selected file diff in right panel
+/// Files tab. Shows files in selected change in main panel and selected file diff in details panel
 pub struct FilesTab {
     head: Head,
     is_current_head: bool,

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -7,7 +7,7 @@ use crate::{
         log::Head,
         CommandError, Commander,
     },
-    env::{Config, DiffFormat},
+    env::{Config, DiffFormat, JJLayout},
     ui::{
         details_panel::DetailsPanel, help_popup::HelpPopup, utils::tabs_to_spaces, Component,
         ComponentAction,
@@ -33,6 +33,7 @@ pub struct FilesTab {
     diff_panel: DetailsPanel,
     diff_output: Result<Option<String>, CommandError>,
     diff_format: DiffFormat,
+    layout_direction: Direction,
 
     config: Config,
 }
@@ -71,6 +72,12 @@ impl FilesTab {
             .map(|current_change| commander.get_file_diff(&head, current_change, &diff_format))
             .map_or(Ok(None), |r| r.map(|diff| Some(tabs_to_spaces(&diff))));
 
+        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
+          Direction::Horizontal
+        } else {
+          Direction::Vertical
+        };
+
         let files_list_state = ListState::default().with_selected(get_current_file_index(
             current_file.as_ref(),
             files_output.as_ref(),
@@ -90,6 +97,7 @@ impl FilesTab {
             diff_output,
             diff_format,
             diff_panel: DetailsPanel::new(),
+            layout_direction,
 
             config: commander.env.config.clone(),
         })
@@ -168,7 +176,7 @@ impl Component for FilesTab {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(Direction::Horizontal)
+            .direction(self.layout_direction)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -70,11 +70,11 @@ impl Component for HelpPopup {
             .split(block_inner);
 
         f.render_widget(
-            self.create_table(&self.left_items, "Left panel".into()),
+            self.create_table(&self.left_items, "Main panel".into()),
             chunks[0],
         );
         f.render_widget(
-            self.create_table(&self.right_items, "Right panel".into()),
+            self.create_table(&self.right_items, "Details panel".into()),
             chunks[2],
         );
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -13,7 +13,7 @@ use crate::{
         log::{Head, LogOutput},
         CommandError, Commander,
     },
-    env::{Config, DiffFormat, JJLayout},
+    env::{Config, DiffFormat},
     ui::{
         bookmark_set_popup::BookmarkSetPopup,
         details_panel::DetailsPanel,
@@ -55,9 +55,6 @@ pub struct LogTab<'a> {
     describe_textarea: Option<TextArea<'a>>,
     describe_after_new: bool,
 
-    layout_direction: Direction,
-    layout_percent: u16,
-
     config: Config,
 }
 
@@ -95,13 +92,6 @@ impl LogTab<'_> {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (bookmark_set_popup_tx, bookmark_set_popup_rx) = std::sync::mpsc::channel();
 
-        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
-            Direction::Horizontal
-        } else {
-            Direction::Vertical
-        };
-        let layout_percent = commander.env.config.layout_percent();
-
         Ok(Self {
             log_output_text: match log_output.as_ref() {
                 Ok(log_output) => log_output
@@ -132,9 +122,6 @@ impl LogTab<'_> {
 
             describe_textarea: None,
             describe_after_new: false,
-
-            layout_direction,
-            layout_percent,
 
             config: commander.env.config.clone(),
         })
@@ -262,10 +249,10 @@ impl Component for LogTab<'_> {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(self.layout_direction)
+            .direction(self.config.layout().into())
             .constraints([
-                Constraint::Percentage(self.layout_percent),
-                Constraint::Percentage(100 - self.layout_percent),
+                Constraint::Percentage(self.config.layout_percent()),
+                Constraint::Percentage(100 - self.config.layout_percent()),
             ])
             .split(area);
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -56,6 +56,7 @@ pub struct LogTab<'a> {
     describe_after_new: bool,
 
     layout_direction: Direction,
+    layout_percent: u16,
 
     config: Config,
 }
@@ -95,10 +96,11 @@ impl LogTab<'_> {
         let (bookmark_set_popup_tx, bookmark_set_popup_rx) = std::sync::mpsc::channel();
 
         let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
-          Direction::Horizontal
+            Direction::Horizontal
         } else {
-          Direction::Vertical
+            Direction::Vertical
         };
+        let layout_percent = commander.env.config.layout_percent();
 
         Ok(Self {
             log_output_text: match log_output.as_ref() {
@@ -132,6 +134,7 @@ impl LogTab<'_> {
             describe_after_new: false,
 
             layout_direction,
+            layout_percent,
 
             config: commander.env.config.clone(),
         })
@@ -260,7 +263,10 @@ impl Component for LogTab<'_> {
     ) -> Result<()> {
         let chunks = Layout::default()
             .direction(self.layout_direction)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints([
+                Constraint::Percentage(self.layout_percent),
+                Constraint::Percentage(100 - self.layout_percent),
+            ])
             .split(area);
 
         // Draw log

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -29,7 +29,7 @@ const NEW_POPUP_ID: u16 = 1;
 const EDIT_POPUP_ID: u16 = 2;
 const ABANDON_POPUP_ID: u16 = 3;
 
-/// Log tab. Shows `jj log` in left panel and shows selected change details of in right panel.
+/// Log tab. Shows `jj log` in main panel and shows selected change details of in details panel.
 pub struct LogTab<'a> {
     log_output: Result<LogOutput, CommandError>,
     log_output_text: Text<'a>,

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -13,7 +13,7 @@ use crate::{
         log::{Head, LogOutput},
         CommandError, Commander,
     },
-    env::{Config, DiffFormat},
+    env::{Config, DiffFormat, JJLayout},
     ui::{
         bookmark_set_popup::BookmarkSetPopup,
         details_panel::DetailsPanel,
@@ -55,6 +55,8 @@ pub struct LogTab<'a> {
     describe_textarea: Option<TextArea<'a>>,
     describe_after_new: bool,
 
+    layout_direction: Direction,
+
     config: Config,
 }
 
@@ -92,6 +94,12 @@ impl LogTab<'_> {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (bookmark_set_popup_tx, bookmark_set_popup_rx) = std::sync::mpsc::channel();
 
+        let layout_direction = if commander.env.config.layout() == JJLayout::Horizontal {
+          Direction::Horizontal
+        } else {
+          Direction::Vertical
+        };
+
         Ok(Self {
             log_output_text: match log_output.as_ref() {
                 Ok(log_output) => log_output
@@ -122,6 +130,8 @@ impl LogTab<'_> {
 
             describe_textarea: None,
             describe_after_new: false,
+
+            layout_direction,
 
             config: commander.env.config.clone(),
         })
@@ -249,7 +259,7 @@ impl Component for LogTab<'_> {
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
         let chunks = Layout::default()
-            .direction(Direction::Horizontal)
+            .direction(self.layout_direction)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 


### PR DESCRIPTION
I use a vertical monitor so the default horizontal layout is pretty much unusable for me.

This PR adds two config options:
- `lazyjj.layout` which is either `"horizontal"` (default) or `"vertical"`
- `lazyjj.layout-percent` which should be an integer between 0 and 100 (default 50) which is the size of the main tab as a percentage of the screen

This PR also renames the "left" pane to the "main" pane and the "right" pane to the "details" pane.