### PR TITLE
Fix bookmark creation popup not closing on Esc

### DIFF
--- a/src/ui/bookmark_set_popup.rs
+++ b/src/ui/bookmark_set_popup.rs
@@ -263,7 +263,9 @@ impl Component for BookmarkSetPopup<'_> {
                         ));
                     }
                     KeyCode::Esc => {
-                        return Ok(ComponentInputResult::Handled);
+                        return Ok(ComponentInputResult::HandledAction(
+                            ComponentAction::SetPopup(None),
+                        ));
                     }
                     _ => {}
                 }


### PR DESCRIPTION
The input handler doesn't close the popup itself, but also marks the action as handled, so the global handler doesn't close it either.

Looking at the surroundind code, returning a SetPopup(None) action seems more natural, so let's do that.

Fixes #56