### PR TITLE
Add h/l keys for prev/next tab

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -68,6 +68,26 @@ impl<'a> App<'a> {
         self.get_tab(self.current_tab)
     }
 
+    // TODO make this generic based on indices
+    pub fn set_prev_tab(&mut self) {
+        self.current_tab = match self.current_tab {
+            Tab::Log => Tab::CommandLog,
+            Tab::Files => Tab::Log,
+            Tab::Bookmarks => Tab::Files,
+            Tab::CommandLog => Tab::Bookmarks,
+        };
+    }
+
+    // TODO make this generic based on indices
+    pub fn set_next_tab(&mut self) {
+        self.current_tab = match self.current_tab {
+            Tab::Log => Tab::Files,
+            Tab::Files => Tab::Bookmarks,
+            Tab::Bookmarks => Tab::CommandLog,
+            Tab::CommandLog => Tab::Log,
+        };
+    }
+
     pub fn set_tab(&mut self, commander: &mut Commander, tab: Tab) -> Result<()> {
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
@@ -255,6 +275,14 @@ impl<'a> App<'a> {
                             }
                             //
                             // Tab switching
+                            if key.code == KeyCode::Char('l')
+                            {
+                                self.set_next_tab();
+                            }
+                            if key.code == KeyCode::Char('h')
+                            {
+                                self.set_prev_tab();
+                            }
                             if let Some((_, tab)) = Tab::VALUES.iter().enumerate().find(|(i, _)| {
                                 key.code
                                     == KeyCode::Char(

--- a/src/app.rs
+++ b/src/app.rs
@@ -68,24 +68,11 @@ impl<'a> App<'a> {
         self.get_tab(self.current_tab)
     }
 
-    // TODO make this generic based on indices
-    pub fn set_prev_tab(&mut self) {
-        self.current_tab = match self.current_tab {
-            Tab::Log => Tab::CommandLog,
-            Tab::Files => Tab::Log,
-            Tab::Bookmarks => Tab::Files,
-            Tab::CommandLog => Tab::Bookmarks,
-        };
-    }
-
-    // TODO make this generic based on indices
-    pub fn set_next_tab(&mut self) {
-        self.current_tab = match self.current_tab {
-            Tab::Log => Tab::Files,
-            Tab::Files => Tab::Bookmarks,
-            Tab::Bookmarks => Tab::CommandLog,
-            Tab::CommandLog => Tab::Log,
-        };
+    pub fn set_next_tab_with_offset(&mut self, commander: &mut Commander, offset: i64) {
+        let current_index = Tab::VALUES.iter().position(|&t| t == self.current_tab).unwrap();
+        let new_index = (current_index as i64 + Tab::VALUES.len() as i64 + offset) as usize % Tab::VALUES.len();
+        let new_tab: Tab = Tab::VALUES[new_index];
+        self.set_tab(commander, new_tab);
     }
 
     pub fn set_tab(&mut self, commander: &mut Commander, tab: Tab) -> Result<()> {
@@ -275,15 +262,15 @@ impl<'a> App<'a> {
                             }
                             //
                             // Tab switching
-                            if key.code == KeyCode::Char('l')
+                            else if key.code == KeyCode::Char('l')
                             {
-                                self.set_next_tab();
+                                self.set_next_tab_with_offset(commander, 1);
                             }
-                            if key.code == KeyCode::Char('h')
+                            else if key.code == KeyCode::Char('h')
                             {
-                                self.set_prev_tab();
+                                self.set_next_tab_with_offset(commander, -1);
                             }
-                            if let Some((_, tab)) = Tab::VALUES.iter().enumerate().find(|(i, _)| {
+                            else if let Some((_, tab)) = Tab::VALUES.iter().enumerate().find(|(i, _)| {
                                 key.code
                                     == KeyCode::Char(
                                         char::from_digit((*i as u32) + 1u32, 10)
@@ -293,7 +280,7 @@ impl<'a> App<'a> {
                                 self.set_tab(commander, *tab)?;
                             }
                             // General jj command runner
-                            if key.code == KeyCode::Char(':') {
+                            else if key.code == KeyCode::Char(':') {
                                 self.popup = Some(Box::new(CommandPopup::new()));
                             }
                         }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -911,7 +911,7 @@ impl Component for BookmarksTab<'_> {
                         }
                     }
                 }
-                KeyCode::Char('h') | KeyCode::Char('?') => {
+                KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(
                         ComponentAction::SetPopup(Some(Box::new(HelpPopup::new(
                             vec![

--- a/src/ui/command_log_tab.rs
+++ b/src/ui/command_log_tab.rs
@@ -260,7 +260,7 @@ impl Component for CommandLogTab {
                 KeyCode::Char('@') => {
                     self.scroll_commands(isize::MIN);
                 }
-                KeyCode::Char('h') | KeyCode::Char('?') => {
+                KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(
                         ComponentAction::SetPopup(Some(Box::new(HelpPopup::new(
                             vec![

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -319,7 +319,7 @@ impl Component for FilesTab {
                     let head = &commander.get_current_head()?;
                     self.set_head(commander, head)?;
                 }
-                KeyCode::Char('h') | KeyCode::Char('?') => {
+                KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(
                         ComponentAction::SetPopup(Some(Box::new(HelpPopup::new(
                             vec![

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -743,7 +743,7 @@ impl Component for LogTab<'_> {
                     self.refresh_log_output(commander);
                     self.refresh_head_output(commander);
                 }
-                KeyCode::Char('h') | KeyCode::Char('?') => {
+                KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(
                         ComponentAction::SetPopup(Some(Box::new(HelpPopup::new(
                             vec![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -86,7 +86,7 @@ pub fn ui(f: &mut Frame, app: &mut App) -> Result<()> {
         f.render_widget(tabs, header_chunks[0]);
     }
     {
-        let tabs = Paragraph::new("q: quit | h: help | R: refresh | 1/2/3/4: change tab")
+        let tabs = Paragraph::new("q: quit | ?: help | R: refresh | 1/2/3/4: change tab")
             .fg(Color::DarkGray)
             .block(
                 Block::bordered()


### PR DESCRIPTION
This add the vim keys 'h' and 'l' shortcuts for going forward and backwards one tab - I sorely missed this, and it's more in line with tools like lazydocker this way. Picking a commit with Return is fine, but hitting 1 to 'go back' is awkward, IMHO. 

Also, since I'm not a rust programmer, take this commit more as a suggestion and feel free to change anything.

edit: Oh, and this obviously removes 'h' as the help key, but since '?' is there already, this should be fine, since this is an operation that's not common, except during the first few times running the program.