### PR TITLE
fix: Workaround timeouts in Mac CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
       - name: Install jj
         run: cargo binstall --no-confirm --strategies crate-meta-data jj-cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test
         run: cargo test --all-targets --verbose
         env:


### PR DESCRIPTION
According to
https://github.com/cargo-bins/cargo-binstall/issues/2045#issuecomment-2678217920 one should export the GITHUB_TOKEN as an environment variable for more reliable cargo-binstall execution in GitHub Actions. cargo-binstall also does this itself. For example: https://github.com/cargo-bins/cargo-binstall/blob/a803508dbf9c51e6ba0a3a68aa5bcb3b8fc6f4e2/.github/workflows/ci.yml#L85C1-L85C92