### PR TITLE
feat: Check jj version at startup (fix #138)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "tracing-subscriber",
  "tui-textarea",
  "tui_confirm_dialog",
+ "version-compare",
 ]
 
 [[package]]
@@ -1433,6 +1434,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = "0.3.19"
 tui-textarea = "0.7.0"
 tui_confirm_dialog = "0.3.1"
+version-compare = "0.2.0"
 
 # Release build optimize size.
 # Run strip manually after build to reduce further.

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -30,7 +30,7 @@ use crate::env::DiffFormat;
 use crate::env::Env;
 
 use ansi_to_tui::IntoText;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Local, TimeDelta};
 use ratatui::{
     style::{Color, Stylize},
@@ -45,6 +45,12 @@ use std::{
     sync::Arc,
 };
 use thiserror::Error;
+use tracing::{instrument, trace};
+use version_compare::{Cmp, compare};
+
+/// The oldest version of jj that is known to work with lazyjj.
+/// 0.22.0 introduced the bookmark command.
+const JJ_MIN_VERSION: &str = "0.22.0";
 
 impl DiffFormat {
     pub fn get_args(&self) -> Vec<&str> {
@@ -192,9 +198,42 @@ impl Commander {
         Ok(())
     }
 
+    #[instrument(level = "trace", skip(self))]
     pub fn init(&self) -> Result<()> {
-        self.execute_void_jj_command(vec!["status"])
-            .context("Failed getting initial status")
+        // Ask jj about its version
+        let (color, quiet) = (false, false);
+        let found_version = self
+            .execute_jj_command(vec!["version"], color, quiet)
+            .context("Run jj version")?;
+
+        // Extract version number
+        if found_version[0..3] != *"jj " {
+            trace!("jj version output \"{}\"", found_version);
+            bail!("Jujutsu version string was not recognized");
+        }
+        let found_version = &found_version[3..].trim();
+        let min_version = JJ_MIN_VERSION;
+
+        trace!(
+            found_version = found_version,
+            min_version = min_version,
+            "Check jj version",
+        );
+
+        // Verify that jj is not too old
+        match compare(found_version, min_version) {
+            Err(_) => bail!(
+                "Unable to compare version '{}' to '{}'",
+                found_version,
+                min_version
+            ),
+            Ok(Cmp::Lt) => bail!(
+                "jujutsu version {} is too old. Must be at least {}",
+                found_version,
+                min_version
+            ),
+            Ok(_) => Ok(()), // found >= min, so jj is recent enough
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> Result<()> {
     let env = Env::new(path, args.revisions, jj_bin)?;
     let mut commander = Commander::new(&env);
 
-    // Check that `jj status` works
+    // Check that jj version is recent enough
     commander.init()?;
 
     // Setup app

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use ratatui::{
     layout::{Alignment, Rect},
     widgets::Paragraph,
 };
-use tracing::{error, info, trace_span, warn};
+use tracing::{info, trace_span};
 use tracing_chrome::ChromeLayerBuilder;
 use tracing_subscriber::layer::SubscriberExt;
 
@@ -130,19 +130,8 @@ fn main() -> Result<()> {
     let env = Env::new(path, args.revisions, jj_bin)?;
     let mut commander = Commander::new(&env);
 
-    // Check that jj version is recent enough
-    if let Err(msg) = commander.init() {
-        if args.ignore_jj_version {
-            let msg = msg.context("Ignoring error due to --ignore-jj-version");
-            warn!("{:?}", msg);
-        } else {
-            let msg = msg.context(
-                "You should upgrade jj to a newer version to use all of lazyjj features.\n\
-                If you want to continue anyway, use --ignore-jj-version",
-            );
-            error!("{:?}", msg);
-            return Err(msg);
-        }
+    if !args.ignore_jj_version {
+        commander.check_jj_version()?;
     }
 
     // Setup app


### PR DESCRIPTION
<!-- Please use conventionalcommits.org for PR title. E.g. prefix with feat:, fix:, chore:, etc -->
Check that jj is at least version 0.22, which introduced the "bookmark" command.

Fix #138