### PR TITLE
fix(bookmarks): Fix crash due to non-total ordering in the sorting lamba

### DIFF
--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -134,14 +134,17 @@ impl Commander {
                 None => BookmarkLine::Unparsable(line_colored.to_owned()),
             })
             .sorted_by(|a, b| {
-                if let (
-                    BookmarkLine::Parsed { bookmark: a, .. },
-                    BookmarkLine::Parsed { bookmark: b, .. },
-                ) = (a, b)
-                {
-                    b.timestamp.cmp(&a.timestamp)
-                } else {
-                    Ordering::Equal
+                use BookmarkLine::*;
+
+                match (a, b) {
+                    (Parsed { bookmark: a, .. }, Parsed { bookmark: b, .. }) => {
+                        b.timestamp.cmp(&a.timestamp)
+                    }
+                    // Just move unparsable lines to the back, we don't care about the actual
+                    // order, but sorted_by() expects to be given a total order
+                    (Parsed { .. }, Unparsable(..)) => Ordering::Less,
+                    (Unparsable(..), Parsed { .. }) => Ordering::Greater,
+                    (Unparsable(..), Unparsable(..)) => Ordering::Equal,
                 }
             })
             .collect();


### PR DESCRIPTION
Given two Parsed and one Unparsable line, the current lambda would return Ordering::Equal for both Parsed/Unparsable pairings, but then possibly declare that the Parsed/Parsed values differ (unless their timestamps are equal). This is contradictory and violates the requirements of the sorted_by() method, causing it to eventually panic.