### PR TITLE
chore: Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -61,36 +61,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -102,9 +102,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -114,18 +114,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cassowary"
@@ -144,24 +144,24 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -208,15 +208,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -322,6 +322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,12 +347,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -369,9 +375,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -387,9 +393,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -451,12 +457,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -468,14 +474,12 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "insta"
-version = "1.42.2"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
- "linked-hash-map",
  "once_cell",
- "pin-project",
  "regex",
  "similar",
 ]
@@ -567,15 +571,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -585,9 +583,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -605,14 +603,14 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -622,14 +620,14 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -683,6 +681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,9 +694,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -700,15 +704,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -716,26 +720,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -778,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -873,11 +857,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -933,15 +937,39 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "scopeguard"
@@ -983,24 +1011,26 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1010,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1043,9 +1073,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1085,9 +1115,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "static_assertions"
@@ -1125,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1186,12 +1216,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1229,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1241,25 +1270,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1274,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1296,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1400,9 +1436,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1495,9 +1531,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1530,35 +1566,26 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]
@@ -1567,7 +1594,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1576,14 +1612,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1593,10 +1645,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1605,10 +1669,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1617,10 +1693,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1629,16 +1717,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.6"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -1654,18 +1754,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -105,20 +105,18 @@ impl Commander {
         );
 
         match output {
-            Ok(output) => {
-                return Ok(output
-                    .lines()
-                    .filter_map(|line| {
-                        let captured = CONFLICTS_REGEX.captures(line);
-                        captured
-                            .as_ref()
-                            .and_then(|captured| captured.get(1))
-                            .map(|inner_text| Conflict {
-                                path: inner_text.as_str().to_owned(),
-                            })
-                    })
-                    .collect())
-            }
+            Ok(output) => Ok(output
+                .lines()
+                .filter_map(|line| {
+                    let captured = CONFLICTS_REGEX.captures(line);
+                    captured
+                        .as_ref()
+                        .and_then(|captured| captured.get(1))
+                        .map(|inner_text| Conflict {
+                            path: inner_text.as_str().to_owned(),
+                        })
+                })
+                .collect()),
             Err(CommandError::Status(_, Some(2))) => {
                 // No conflicts
                 Ok(vec![])


### PR DESCRIPTION
| Package                       | From    | To      | Compare   |
|-------------------------------|---------|---------|-----------|
| [anstream][01]                | 0.6.18  | 0.6.19  | [...][02] |
| [anstyle][03]                 | 1.0.10  | 1.0.11  | [...][04] |
| [anstyle-parse][05]           | 0.2.6   | 0.2.7   | [...][06] |
| [anstyle-query][07]           | 1.1.2   | 1.1.3   | [...][08] |
| [anstyle-wincon][09]          | 3.0.7   | 3.0.9   | [...][0A] |
| [autocfg][0B]                 | 1.4.0   | 1.5.0   | [...][0C] |
| [bitflags][0D]                | 2.9.0   | 2.9.1   | [...][0E] |
| [bumpalo][0F]                 | 3.17.0  | 3.19.0  | [...][10] |
| [cc][11]                      | 1.2.19  | 1.2.29  | [...][12] |
| [cfg-if][13]                  | 1.0.0   | 1.0.1   | [...][14] |
| [chrono][15]                  | 0.4.40  | 0.4.41  | [...][16] |
| [clap][17]                    | 4.5.37  | 4.5.40  | [...][18] |
| [clap_builder][19]            | 4.5.37  | 4.5.40  | [...][1A] |
| [clap_derive][1B]             | 4.5.32  | 4.5.40  | [...][1C] |
| [clap_lex][1D]                | 0.7.4   | 0.7.5   | [...][1E] |
| [colorchoice][1F]             | 1.0.3   | 1.0.4   | [...][20] |
| [dyn-clone][21]               | NEW     | 1.0.19  |           |
| [errno][22]                   | 0.3.11  | 0.3.13  | [...][23] |
| [getrandom][24]               | 0.3.2   | 0.3.3   | [...][25] |
| [hashbrown][26]               | 0.15.2  | 0.15.4  | [...][27] |
| [indexmap][28]                | 2.9.0   | 2.10.0  | [...][29] |
| [insta][2A]                   | 1.42.2  | 1.43.1  | [...][2B] |
| [libc][2C]                    | 0.2.172 | 0.2.174 | [...][2D] |
| linked-hash-map               | 0.5.6   | REMOVED |           |
| [lock_api][2E]                | 0.4.12  | 0.4.13  | [...][2F] |
| [memchr][30]                  | 2.7.4   | 2.7.5   | [...][31] |
| [mio][32]                     | 1.0.3   | 1.0.4   | [...][33] |
| [once_cell_polyfill][34]      | NEW     | 1.70.1  |           |
| [parking_lot][35]             | 0.12.3  | 0.12.4  | [...][36] |
| [parking_lot_core][37]        | 0.9.10  | 0.9.11  | [...][38] |
| pin-project                   | 1.1.10  | REMOVED |           |
| pin-project-internal          | 1.1.10  | REMOVED |           |
| [r-efi][39]                   | 5.2.0   | 5.3.0   | [...][3A] |
| [redox_syscall][3B]           | 0.5.11  | 0.5.13  | [...][3C] |
| [ref-cast][3D]                | NEW     | 1.0.24  |           |
| [ref-cast-impl][3E]           | NEW     | 1.0.24  |           |
| [rustversion][3F]             | 1.0.20  | 1.0.21  | [...][40] |
| [schemars][41]                | NEW     | 1.0.4   |           |
| [serde_spanned][42]           | 0.6.8   | 0.6.9   | [...][43] |
| [serde_with][44]              | 3.12.0  | 3.14.0  | [...][45] |
| [serde_with_macros][46]       | 3.12.0  | 3.14.0  | [...][47] |
| [signal-hook][48]             | 0.3.17  | 0.3.18  | [...][49] |
| [smallvec][4A]                | 1.15.0  | 1.15.1  | [...][4B] |
| [syn][4C]                     | 2.0.100 | 2.0.104 | [...][4D] |
| [thread_local][4E]            | 1.1.8   | 1.1.9   | [...][4F] |
| [toml][50]                    | 0.8.20  | 0.8.23  | [...][51] |
| [toml_datetime][52]           | 0.6.8   | 0.6.11  | [...][53] |
| [toml_edit][54]               | 0.22.24 | 0.22.27 | [...][55] |
| [toml_write][56]              | NEW     | 0.1.2   |           |
| [tracing-attributes][57]      | 0.1.28  | 0.1.30  | [...][58] |
| [tracing-core][59]            | 0.1.33  | 0.1.34  | [...][5A] |
| [windows-core][5B]            | 0.61.0  | 0.61.2  | [...][5C] |
| [windows-link][5D]            | 0.1.1   | 0.1.3   | [...][5E] |
| [windows-result][5F]          | 0.3.2   | 0.3.4   | [...][60] |
| [windows-strings][61]         | 0.4.0   | 0.4.2   | [...][62] |
| [windows-sys][63]             | NEW     | 0.60.2  |           |
| [windows-targets][64]         | NEW     | 0.53.2  |           |
| [windows_aarch64_gnullvm][65] | NEW     | 0.53.0  |           |
| [windows_aarch64_msvc][66]    | NEW     | 0.53.0  |           |
| [windows_i686_gnu][67]        | NEW     | 0.53.0  |           |
| [windows_i686_gnullvm][68]    | NEW     | 0.53.0  |           |
| [windows_i686_msvc][69]       | NEW     | 0.53.0  |           |
| [windows_x86_64_gnu][6A]      | NEW     | 0.53.0  |           |
| [windows_x86_64_gnullvm][6B]  | NEW     | 0.53.0  |           |
| [windows_x86_64_msvc][6C]     | NEW     | 0.53.0  |           |
| [winnow][6D]                  | 0.7.6   | 0.7.11  | [...][6E] |
| [zerocopy][6F]                | 0.8.24  | 0.8.26  | [...][70] |
| [zerocopy-derive][71]         | 0.8.24  | 0.8.26  | [...][72] |

[01]: https://crates.io/crates/anstream
[02]: https://diff.rs/anstream/0%2E6%2E18/anstream/0%2E6%2E19/Cargo.toml
[03]: https://crates.io/crates/anstyle
[04]: https://diff.rs/anstyle/1%2E0%2E10/anstyle/1%2E0%2E11/Cargo.toml
[05]: https://crates.io/crates/anstyle-parse
[06]: https://diff.rs/anstyle%2Dparse/0%2E2%2E6/anstyle%2Dparse/0%2E2%2E7/Cargo.toml
[07]: https://crates.io/crates/anstyle-query
[08]: https://diff.rs/anstyle%2Dquery/1%2E1%2E2/anstyle%2Dquery/1%2E1%2E3/Cargo.toml
[09]: https://crates.io/crates/anstyle-wincon
[0A]: https://diff.rs/anstyle%2Dwincon/3%2E0%2E7/anstyle%2Dwincon/3%2E0%2E9/Cargo.toml
[0B]: https://crates.io/crates/autocfg
[0C]: https://diff.rs/autocfg/1%2E4%2E0/autocfg/1%2E5%2E0/Cargo.toml
[0D]: https://crates.io/crates/bitflags
[0E]: https://diff.rs/bitflags/2%2E9%2E0/bitflags/2%2E9%2E1/Cargo.toml
[0F]: https://crates.io/crates/bumpalo
[10]: https://diff.rs/bumpalo/3%2E17%2E0/bumpalo/3%2E19%2E0/Cargo.toml
[11]: https://crates.io/crates/cc
[12]: https://diff.rs/cc/1%2E2%2E19/cc/1%2E2%2E29/Cargo.toml
[13]: https://crates.io/crates/cfg-if
[14]: https://diff.rs/cfg%2Dif/1%2E0%2E0/cfg%2Dif/1%2E0%2E1/Cargo.toml
[15]: https://crates.io/crates/chrono
[16]: https://diff.rs/chrono/0%2E4%2E40/chrono/0%2E4%2E41/Cargo.toml
[17]: https://crates.io/crates/clap
[18]: https://diff.rs/clap/4%2E5%2E37/clap/4%2E5%2E40/Cargo.toml
[19]: https://crates.io/crates/clap_builder
[1A]: https://diff.rs/clap%5Fbuilder/4%2E5%2E37/clap%5Fbuilder/4%2E5%2E40/Cargo.toml
[1B]: https://crates.io/crates/clap_derive
[1C]: https://diff.rs/clap%5Fderive/4%2E5%2E32/clap%5Fderive/4%2E5%2E40/Cargo.toml
[1D]: https://crates.io/crates/clap_lex
[1E]: https://diff.rs/clap%5Flex/0%2E7%2E4/clap%5Flex/0%2E7%2E5/Cargo.toml
[1F]: https://crates.io/crates/colorchoice
[20]: https://diff.rs/colorchoice/1%2E0%2E3/colorchoice/1%2E0%2E4/Cargo.toml
[21]: https://crates.io/crates/dyn-clone
[22]: https://crates.io/crates/errno
[23]: https://diff.rs/errno/0%2E3%2E11/errno/0%2E3%2E13/Cargo.toml
[24]: https://crates.io/crates/getrandom
[25]: https://diff.rs/getrandom/0%2E3%2E2/getrandom/0%2E3%2E3/Cargo.toml
[26]: https://crates.io/crates/hashbrown
[27]: https://diff.rs/hashbrown/0%2E15%2E2/hashbrown/0%2E15%2E4/Cargo.toml
[28]: https://crates.io/crates/indexmap
[29]: https://diff.rs/indexmap/2%2E9%2E0/indexmap/2%2E10%2E0/Cargo.toml
[2A]: https://crates.io/crates/insta
[2B]: https://diff.rs/insta/1%2E42%2E2/insta/1%2E43%2E1/Cargo.toml
[2C]: https://crates.io/crates/libc
[2D]: https://diff.rs/libc/0%2E2%2E172/libc/0%2E2%2E174/Cargo.toml
[2E]: https://crates.io/crates/lock_api
[2F]: https://diff.rs/lock%5Fapi/0%2E4%2E12/lock%5Fapi/0%2E4%2E13/Cargo.toml
[30]: https://crates.io/crates/memchr
[31]: https://diff.rs/memchr/2%2E7%2E4/memchr/2%2E7%2E5/Cargo.toml
[32]: https://crates.io/crates/mio
[33]: https://diff.rs/mio/1%2E0%2E3/mio/1%2E0%2E4/Cargo.toml
[34]: https://crates.io/crates/once_cell_polyfill
[35]: https://crates.io/crates/parking_lot
[36]: https://diff.rs/parking%5Flot/0%2E12%2E3/parking%5Flot/0%2E12%2E4/Cargo.toml
[37]: https://crates.io/crates/parking_lot_core
[38]: https://diff.rs/parking%5Flot%5Fcore/0%2E9%2E10/parking%5Flot%5Fcore/0%2E9%2E11/Cargo.toml
[39]: https://crates.io/crates/r-efi
[3A]: https://diff.rs/r%2Defi/5%2E2%2E0/r%2Defi/5%2E3%2E0/Cargo.toml
[3B]: https://crates.io/crates/redox_syscall
[3C]: https://diff.rs/redox%5Fsyscall/0%2E5%2E11/redox%5Fsyscall/0%2E5%2E13/Cargo.toml
[3D]: https://crates.io/crates/ref-cast
[3E]: https://crates.io/crates/ref-cast-impl
[3F]: https://crates.io/crates/rustversion
[40]: https://diff.rs/rustversion/1%2E0%2E20/rustversion/1%2E0%2E21/Cargo.toml
[41]: https://crates.io/crates/schemars
[42]: https://crates.io/crates/serde_spanned
[43]: https://diff.rs/serde%5Fspanned/0%2E6%2E8/serde%5Fspanned/0%2E6%2E9/Cargo.toml
[44]: https://crates.io/crates/serde_with
[45]: https://diff.rs/serde%5Fwith/3%2E12%2E0/serde%5Fwith/3%2E14%2E0/Cargo.toml
[46]: https://crates.io/crates/serde_with_macros
[47]: https://diff.rs/serde%5Fwith%5Fmacros/3%2E12%2E0/serde%5Fwith%5Fmacros/3%2E14%2E0/Cargo.toml
[48]: https://crates.io/crates/signal-hook
[49]: https://diff.rs/signal%2Dhook/0%2E3%2E17/signal%2Dhook/0%2E3%2E18/Cargo.toml
[4A]: https://crates.io/crates/smallvec
[4B]: https://diff.rs/smallvec/1%2E15%2E0/smallvec/1%2E15%2E1/Cargo.toml
[4C]: https://crates.io/crates/syn
[4D]: https://diff.rs/syn/2%2E0%2E100/syn/2%2E0%2E104/Cargo.toml
[4E]: https://crates.io/crates/thread_local
[4F]: https://diff.rs/thread%5Flocal/1%2E1%2E8/thread%5Flocal/1%2E1%2E9/Cargo.toml
[50]: https://crates.io/crates/toml
[51]: https://diff.rs/toml/0%2E8%2E20/toml/0%2E8%2E23/Cargo.toml
[52]: https://crates.io/crates/toml_datetime
[53]: https://diff.rs/toml%5Fdatetime/0%2E6%2E8/toml%5Fdatetime/0%2E6%2E11/Cargo.toml
[54]: https://crates.io/crates/toml_edit
[55]: https://diff.rs/toml%5Fedit/0%2E22%2E24/toml%5Fedit/0%2E22%2E27/Cargo.toml
[56]: https://crates.io/crates/toml_write
[57]: https://crates.io/crates/tracing-attributes
[58]: https://diff.rs/tracing%2Dattributes/0%2E1%2E28/tracing%2Dattributes/0%2E1%2E30/Cargo.toml
[59]: https://crates.io/crates/tracing-core
[5A]: https://diff.rs/tracing%2Dcore/0%2E1%2E33/tracing%2Dcore/0%2E1%2E34/Cargo.toml
[5B]: https://crates.io/crates/windows-core
[5C]: https://diff.rs/windows%2Dcore/0%2E61%2E0/windows%2Dcore/0%2E61%2E2/Cargo.toml
[5D]: https://crates.io/crates/windows-link
[5E]: https://diff.rs/windows%2Dlink/0%2E1%2E1/windows%2Dlink/0%2E1%2E3/Cargo.toml
[5F]: https://crates.io/crates/windows-result
[60]: https://diff.rs/windows%2Dresult/0%2E3%2E2/windows%2Dresult/0%2E3%2E4/Cargo.toml
[61]: https://crates.io/crates/windows-strings
[62]: https://diff.rs/windows%2Dstrings/0%2E4%2E0/windows%2Dstrings/0%2E4%2E2/Cargo.toml
[63]: https://crates.io/crates/windows-sys
[64]: https://crates.io/crates/windows-targets
[65]: https://crates.io/crates/windows_aarch64_gnullvm
[66]: https://crates.io/crates/windows_aarch64_msvc
[67]: https://crates.io/crates/windows_i686_gnu
[68]: https://crates.io/crates/windows_i686_gnullvm
[69]: https://crates.io/crates/windows_i686_msvc
[6A]: https://crates.io/crates/windows_x86_64_gnu
[6B]: https://crates.io/crates/windows_x86_64_gnullvm
[6C]: https://crates.io/crates/windows_x86_64_msvc
[6D]: https://crates.io/crates/winnow
[6E]: https://diff.rs/winnow/0%2E7%2E6/winnow/0%2E7%2E11/Cargo.toml
[6F]: https://crates.io/crates/zerocopy
[70]: https://diff.rs/zerocopy/0%2E8%2E24/zerocopy/0%2E8%2E26/Cargo.toml
[71]: https://crates.io/crates/zerocopy-derive
[72]: https://diff.rs/zerocopy%2Dderive/0%2E8%2E24/zerocopy%2Dderive/0%2E8%2E26/Cargo.toml
