### PR TITLE
fix: Changing description should not move selection

### DIFF
--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -761,7 +761,7 @@ impl Component for LogTab<'_> {
                             self.head.commit_id.as_str(),
                             &describe_textarea.lines().join("\n"),
                         )?;
-                        self.head = commander.get_current_head()?;
+                        self.head = commander.get_head_latest(&self.head)?;
                         self.refresh_log_output(commander);
                         self.refresh_head_output(commander);
                         self.describe_textarea = None;


### PR DESCRIPTION
<!-- Please use conventionalcommits.org for PR title. E.g. prefix with feat:, fix:, chore:, etc -->
PR 143 introduced a bug that would move the selection to revision @ after a describe command.