### PR TITLE
doc: Recommend `--locked` for cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ https://github.com/Cretezy/lazyjj/assets/2672503/b5e6b4f1-ebdb-448f-af9e-361e86f
 Make sure you have [`jj`](https://martinvonz.github.io/jj/latest/install-and-setup) installed first.
 
 - With [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall): `cargo binstall lazyjj`
-- With `cargo install`: `cargo install lazyjj` (may take a few moments to compile)
+- With `cargo install`: `cargo install lazyjj --locked` (may take a few moments to compile)
 - With pre-built binaries: [View releases](https://github.com/Cretezy/lazyjj/releases)
 - For Arch Linux: `pacman -S lazyjj`
 


### PR DESCRIPTION
Recommend the use of `--locked` when installing `lazyjj` with `cargo install`

Related to #153 