### PR TITLE
fix: jj 0.33.0 and Rust 1.89.0 compatibility

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -230,20 +230,20 @@ impl<'a> App<'a> {
                 }
                 ComponentInputResult::Handled => {}
                 ComponentInputResult::NotHandled => {
-                    if let Event::Key(key) = event {
-                        if key.kind == event::KeyEventKind::Press {
-                            // Close
-                            if matches!(
-                                key.code,
-                                KeyCode::Char('y')
-                                    | KeyCode::Char('n')
-                                    | KeyCode::Char('o')
-                                    | KeyCode::Enter
-                                    | KeyCode::Char('q')
-                                    | KeyCode::Esc
-                            ) {
-                                self.popup = None
-                            }
+                    if let Event::Key(key) = event
+                        && key.kind == event::KeyEventKind::Press
+                    {
+                        // Close
+                        if matches!(
+                            key.code,
+                            KeyCode::Char('y')
+                                | KeyCode::Char('n')
+                                | KeyCode::Char('o')
+                                | KeyCode::Enter
+                                | KeyCode::Char('q')
+                                | KeyCode::Esc
+                        ) {
+                            self.popup = None
                         }
                     }
                 }
@@ -260,38 +260,37 @@ impl<'a> App<'a> {
                 }
                 ComponentInputResult::Handled => {}
                 ComponentInputResult::NotHandled => {
-                    if let Event::Key(key) = event {
-                        if key.kind == event::KeyEventKind::Press {
-                            // Close
-                            if key.code == KeyCode::Char('q')
-                                || (key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && (key.code == KeyCode::Char('c')))
-                                || key.code == KeyCode::Esc
-                            {
-                                return Ok(true);
-                            }
-                            //
-                            // Tab switching
-                            else if key.code == KeyCode::Char('l') {
-                                self.set_next_tab_with_offset(commander, 1)?;
-                            } else if key.code == KeyCode::Char('h') {
-                                self.set_next_tab_with_offset(commander, -1)?;
-                            } else if let Some((_, tab)) =
-                                Tab::VALUES.iter().enumerate().find(|(i, _)| {
-                                    key.code
-                                        == KeyCode::Char(
-                                            char::from_digit((*i as u32) + 1u32, 10).expect(
-                                                "Tab index could not be converted to digit",
-                                            ),
-                                        )
-                                })
-                            {
-                                self.set_tab(commander, *tab)?;
-                            }
-                            // General jj command runner
-                            else if key.code == KeyCode::Char(':') {
-                                self.popup = Some(Box::new(CommandPopup::new()));
-                            }
+                    if let Event::Key(key) = event
+                        && key.kind == event::KeyEventKind::Press
+                    {
+                        // Close
+                        if key.code == KeyCode::Char('q')
+                            || (key.modifiers.contains(KeyModifiers::CONTROL)
+                                && (key.code == KeyCode::Char('c')))
+                            || key.code == KeyCode::Esc
+                        {
+                            return Ok(true);
+                        }
+                        //
+                        // Tab switching
+                        else if key.code == KeyCode::Char('l') {
+                            self.set_next_tab_with_offset(commander, 1)?;
+                        } else if key.code == KeyCode::Char('h') {
+                            self.set_next_tab_with_offset(commander, -1)?;
+                        } else if let Some((_, tab)) =
+                            Tab::VALUES.iter().enumerate().find(|(i, _)| {
+                                key.code
+                                    == KeyCode::Char(
+                                        char::from_digit((*i as u32) + 1u32, 10)
+                                            .expect("Tab index could not be converted to digit"),
+                                    )
+                            })
+                        {
+                            self.set_tab(commander, *tab)?;
+                        }
+                        // General jj command runner
+                        else if key.code == KeyCode::Char(':') {
+                            self.popup = Some(Box::new(CommandPopup::new()));
                         }
                     }
                 }

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -77,7 +77,7 @@ pub enum BookmarkLine {
 }
 
 impl BookmarkLine {
-    pub fn to_text(&self) -> Result<Text, ansi_to_tui::Error> {
+    pub fn to_text(&self) -> Result<Text<'_>, ansi_to_tui::Error> {
         match self {
             BookmarkLine::Unparsable(text) => text.to_text(),
             BookmarkLine::Parsed { text, .. } => text.to_text(),

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -99,16 +99,14 @@ impl Commander {
                 vec![
                     "bookmark",
                     "list",
-                    "--config-toml",
+                    "--config",
                     // Override format_ref_targets to not list conflicts
-                    r#"
-                            template-aliases.'format_ref_targets(ref)' = '''
-                                if(ref.conflict(),
-                                  " " ++ label("conflict", "(conflicted)"),
-                                  ": " ++ format_commit_summary_with_refs(ref.normal_target(), ""),
-                                )
-                            '''
-                        "#,
+                    r#"template-aliases.'format_ref_targets(ref)'='''
+                        if(ref.conflict(),
+                          " " ++ label("conflict", "(conflicted)"),
+                          ": " ++ format_commit_summary_with_refs(ref.normal_target(), ""),
+                        )
+                    '''"#,
                 ],
                 args.clone(),
             ]

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -212,7 +212,7 @@ impl Commander {
                         "obslog",
                         "--no-graph",
                         "--template",
-                        r#"change_id ++ "\n""#,
+                        r#"commit.change_id() ++ "\n""#,
                         "-r",
                         latest_head.commit_id.as_str(),
                     ],

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,12 +118,12 @@ fn main() -> Result<()> {
     let jj_bin = args.jj_bin.unwrap_or("jj".to_string());
 
     // Check that jj exists
-    if let Err(err) = Command::new(&jj_bin).arg("help").output() {
-        if err.kind() == ErrorKind::NotFound {
-            bail!(
-                "jj command not found. Please make sure it is installed: https://martinvonz.github.io/jj/latest/install-and-setup"
-            );
-        }
+    if let Err(err) = Command::new(&jj_bin).arg("help").output()
+        && err.kind() == ErrorKind::NotFound
+    {
+        bail!(
+            "jj command not found. Please make sure it is installed: https://martinvonz.github.io/jj/latest/install-and-setup"
+        );
     }
 
     // Setup environment

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -46,12 +46,12 @@ fn get_current_file_index(
     current_file: Option<&File>,
     files_output: Result<&Vec<File>, &CommandError>,
 ) -> Option<usize> {
-    if let (Some(current_file), Ok(files_output)) = (current_file, files_output) {
-        if let Some(path) = current_file.path.as_ref() {
-            return files_output
-                .iter()
-                .position(|file| file.path.as_ref() == Some(path));
-        }
+    if let (Some(current_file), Ok(files_output)) = (current_file, files_output)
+        && let Some(path) = current_file.path.as_ref()
+    {
+        return files_output
+            .iter()
+            .position(|file| file.path.as_ref() == Some(path));
     }
 
     None

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -86,20 +86,19 @@ impl Component for HelpPopup {
         _commander: &mut crate::commander::Commander,
         event: Event,
     ) -> anyhow::Result<crate::ComponentInputResult> {
-        if let Event::Key(key) = event {
-            if key.kind == event::KeyEventKind::Press {
-                match key.code {
-                    KeyCode::Char('j') => {
-                        let max = self.left_items.len().max(self.right_items.len());
-                        self.scroll =
-                            (self.scroll + 1).min(max.saturating_sub(self.height as usize));
-                    }
-                    KeyCode::Char('k') => self.scroll = self.scroll.saturating_sub(1),
-                    _ => return Ok(ComponentInputResult::NotHandled),
+        if let Event::Key(key) = event
+            && key.kind == event::KeyEventKind::Press
+        {
+            match key.code {
+                KeyCode::Char('j') => {
+                    let max = self.left_items.len().max(self.right_items.len());
+                    self.scroll = (self.scroll + 1).min(max.saturating_sub(self.height as usize));
                 }
-
-                return Ok(ComponentInputResult::Handled);
+                KeyCode::Char('k') => self.scroll = self.scroll.saturating_sub(1),
+                _ => return Ok(ComponentInputResult::NotHandled),
             }
+
+            return Ok(ComponentInputResult::Handled);
         }
 
         Ok(ComponentInputResult::NotHandled)

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -29,7 +29,7 @@ impl HelpPopup {
         }
     }
 
-    fn create_table(&self, items: &[(String, String)], title: String) -> Table {
+    fn create_table(&self, items: &[(String, String)], title: String) -> Table<'_> {
         let items: Vec<&(String, String)> = items.iter().skip(self.scroll).collect();
 
         let max_first_row_width = items.iter().map(|row| row.0.len()).max().unwrap_or(0);

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -510,55 +510,52 @@ impl Component for LogTab<'_> {
 
     fn update(&mut self, commander: &mut Commander) -> Result<Option<ComponentAction>> {
         // Check for popup action
-        if let Ok(res) = self.popup_rx.try_recv() {
-            if res.1.unwrap_or(false) {
-                match res.0 {
-                    NEW_POPUP_ID => {
-                        commander.run_new(self.head.commit_id.as_str())?;
-                        self.head = commander.get_current_head()?;
-                        self.refresh_log_output(commander);
-                        self.refresh_head_output(commander);
-                        if self.describe_after_new {
-                            self.describe_after_new = false;
-                            let textarea = TextArea::default();
-                            self.describe_textarea = Some(textarea);
-                        }
-                        return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
+        if let Ok(res) = self.popup_rx.try_recv()
+            && res.1.unwrap_or(false)
+        {
+            match res.0 {
+                NEW_POPUP_ID => {
+                    commander.run_new(self.head.commit_id.as_str())?;
+                    self.head = commander.get_current_head()?;
+                    self.refresh_log_output(commander);
+                    self.refresh_head_output(commander);
+                    if self.describe_after_new {
+                        self.describe_after_new = false;
+                        let textarea = TextArea::default();
+                        self.describe_textarea = Some(textarea);
                     }
-                    EDIT_POPUP_ID => {
-                        commander
-                            .run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
-                        self.refresh_log_output(commander);
-                        self.refresh_head_output(commander);
-                        return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
-                    }
-                    ABANDON_POPUP_ID => {
-                        if self.head == commander.get_current_head()? {
-                            commander.run_abandon(&self.head.commit_id)?;
-                            self.refresh_log_output(commander);
-                            self.head = commander.get_current_head()?;
-                            self.refresh_head_output(commander);
-                            return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
-                        } else {
-                            let head_parent = commander.get_commit_parent(&self.head.commit_id)?;
-                            commander.run_abandon(&self.head.commit_id)?;
-                            self.refresh_log_output(commander);
-                            self.head = head_parent;
-                            self.refresh_head_output(commander);
-                        }
-                    }
-                    SQUASH_POPUP_ID => {
-                        commander.run_squash(
-                            self.head.commit_id.as_str(),
-                            self.squash_ignore_immutable,
-                        )?;
-                        self.head = commander.get_current_head()?;
-                        self.refresh_log_output(commander);
-                        self.refresh_head_output(commander);
-                        return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
-                    }
-                    _ => {}
+                    return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
                 }
+                EDIT_POPUP_ID => {
+                    commander.run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
+                    self.refresh_log_output(commander);
+                    self.refresh_head_output(commander);
+                    return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
+                }
+                ABANDON_POPUP_ID => {
+                    if self.head == commander.get_current_head()? {
+                        commander.run_abandon(&self.head.commit_id)?;
+                        self.refresh_log_output(commander);
+                        self.head = commander.get_current_head()?;
+                        self.refresh_head_output(commander);
+                        return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
+                    } else {
+                        let head_parent = commander.get_commit_parent(&self.head.commit_id)?;
+                        commander.run_abandon(&self.head.commit_id)?;
+                        self.refresh_log_output(commander);
+                        self.head = head_parent;
+                        self.refresh_head_output(commander);
+                    }
+                }
+                SQUASH_POPUP_ID => {
+                    commander
+                        .run_squash(self.head.commit_id.as_str(), self.squash_ignore_immutable)?;
+                    self.head = commander.get_current_head()?;
+                    self.refresh_log_output(commander);
+                    self.refresh_head_output(commander);
+                    return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
+                }
+                _ => {}
             }
         }
 

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -15,7 +15,7 @@ pub static POPUP_BLOCK: LazyLock<Block<'static>> = LazyLock::new(|| {
 });
 pub static POPUP_BLOCK_TITLE_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().bold().cyan());
 
-pub fn create_popup_block(title: &str) -> Block {
+pub fn create_popup_block(title: &str) -> Block<'_> {
     POPUP_BLOCK
         .clone()
         .title(Span::styled(format!(" {title} "), *POPUP_BLOCK_TITLE_STYLE))


### PR DESCRIPTION
--config-toml has been removed so we need to use --config instead, which has a bit stricter format requirements. No leading/trailing new lines, and no spaces around the equal sign.

It can also only take a single option at a time, so we need to change jj_config_toml from a String to a Vec<String>.

And for obslog/evolog, the template format has changed, so we need to
update that as well.