### PR TITLE
fix: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazyjj"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lazyjj"
 description = "TUI for Jujutsu/jj"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
bump version to 0.6.0

- https://github.com/Homebrew/homebrew-core/pull/236832