### PR TITLE
ci: fix release trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions: read-all
 


### PR DESCRIPTION
I think the workflows didn't start when release was published because I created a draft release first

- see note about `published` [here](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)
- [description of types](https://docs.github.com/en/webhooks/webhook-events-and-payloads#release)

The same type is used in the `winget` workflow, and this workflow was triggered:

https://github.com/Cretezy/lazyjj/blob/bcd046a18866cc09d5d545d12d9d6e40e5445e1d/.github/workflows/winget.yml#L7

This should resolve issue #170

I will close it manually after testing