### PR TITLE
fix: Pop keyboard enhancement flags on exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use ratatui::{
         event::{
             self, DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture,
             Event, KeyboardEnhancementFlags, MouseEvent, MouseEventKind,
-            PushKeyboardEnhancementFlags,
+            PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
         },
         execute,
         terminal::{
@@ -247,12 +247,18 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
 
 fn restore_terminal() -> Result<()> {
     disable_raw_mode()?;
+    let mut stdout = io::stdout();
     execute!(
-        io::stdout(),
+        stdout,
         LeaveAlternateScreen,
         DisableMouseCapture,
         DisableFocusChange
     )?;
+
+    if supports_keyboard_enhancement()? {
+        execute!(stdout, PopKeyboardEnhancementFlags)?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes terminal corruption after exit where Ctrl+ keys would output CSI u sequences instead of normal behavior.

I started noticing this issue on iTerm2 on macOS recently. [It seems like iTerm2 has been making their CSI u handling more strict lately](https://iterm2.com/documentation-csiu.html).