### PR TITLE
fix: Set COLUMNS to details panel width (close #173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Details panel responds to mouse scroll in all tabs
+- Details panel sets COLUMNS to allow jj diff tool to fit window

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -181,6 +181,8 @@ impl BookmarksTab<'_> {
     }
 
     pub fn refresh_bookmark(&mut self, commander: &mut Commander) {
+        let inner_width = self.bookmark_panel.columns() as usize;
+        commander.limit_width(inner_width);
         self.bookmark_output = self.bookmark.as_ref().and_then(|bookmark| match bookmark {
             BookmarkLine::Parsed { bookmark, .. } => Some(
                 commander

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -132,6 +132,8 @@ impl FilesTab {
     }
 
     pub fn refresh_diff(&mut self, commander: &mut Commander) -> Result<()> {
+        let inner_width = self.diff_panel.columns() as usize;
+        commander.limit_width(inner_width);
         self.diff_output = self
             .file
             .as_ref()

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -142,6 +142,8 @@ impl<'a> LogTab<'a> {
     }
 
     fn refresh_head_output(&mut self, commander: &mut Commander) {
+        let inner_width = self.head_panel.columns() as usize;
+        commander.limit_width(inner_width);
         self.head_output = commander
             .get_commit_show(&self.head.commit_id, &self.diff_format, true)
             .map(|text| tabs_to_spaces(&text));


### PR DESCRIPTION
<!-- Please use conventionalcommits.org for PR title. E.g. prefix with feat:, fix:, chore:, etc -->
This PR has two sections
The first is a refactoring that moves code into a panel module.
The second is a new feature: Setting COLUMNS before calling `jj show` to get the change details.