### PR TITLE
fix: freeze on divergent head

### DIFF
--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -187,10 +187,10 @@ impl Commander {
             vec![
                 "log",
                 "--no-graph",
+                "-r",
+                &format!(r#"change_id({})"#, head.change_id.as_str()),
                 "--template",
                 &format!(r#"{HEAD_TEMPLATE} ++ "\n""#),
-                "-r",
-                head.change_id.as_str(),
             ],
             false,
             true,


### PR DESCRIPTION
First of all, thank you for the time and effort you've put into lazyjj !
Fixes: #172

As @peso mentioned, this happens because starting at 0.32:
> In revsets, symbol expressions (such as change ID prefix) no longer resolve to
multiple revisions, and error out if resolved to more than one revisions

So for us, `get_head_latest` would always fail.

This is fixed by sending `change_id(prefix) `.

I have been using daily a fork with this commit for over a week and found no problems with it