### PR TITLE
fix: send file paths as filesets

### DIFF
--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -151,7 +151,8 @@ impl Commander {
             path
         };
 
-        let mut args = vec!["diff", "-r", head.commit_id.as_str(), path];
+        let fileset = format!("file:\"{}\"", path.replace('"', "\\\""));
+        let mut args = vec!["diff", "-r", head.commit_id.as_str(), &fileset];
         args.append(&mut diff_format.get_args());
         if ignore_working_copy {
             args.push("--ignore-working-copy");
@@ -177,8 +178,9 @@ impl Commander {
             path
         };
 
+        let fileset = format!("file:\"{}\"", path.replace('"', "\\\""));
         Ok(Some(self.execute_jj_command(
-            vec!["file", "untrack", path],
+            vec!["file", "untrack", &fileset],
             false,
             true,
         )?))


### PR DESCRIPTION
Thanks again for the time and effort you've put into lazyjj !

This fixes an error where if a path contains `:` jj tries to parse it as a [fileset](https://jj-vcs.github.io/jj/latest/filesets/). The error is this:
> Error: Failed to parse fileset: Syntax error
Caused by:  --> 1:1
  |
1 | :hola
  | ^---
  |
  = expected <strict_identifier>, <bare_string>, or <expression>
Hint: See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.

This fixes it by prefixing the path with `path:` so it "Matches cwd-relative path prefix (file or files under directory recursively.)"
I have been using daily a fork with this commit for over a week and found no problems with it