### PR TITLE
fix: update details pane on focus

### DIFF
--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -439,6 +439,7 @@ impl Component for LogTab<'_> {
     fn focus(&mut self, commander: &mut Commander) -> Result<()> {
         let latest_head = commander.get_head_latest(&self.head)?;
         self.log_panel.set_head(latest_head);
+        self.sync_head_output(commander);
         Ok(())
     }
 


### PR DESCRIPTION
Thanks again for the time and effort you've put into lazyjj !

This fixes a small regression from #169 

After #169, lazyjj does not refresh the details pane (the one that shows the diff) when I make changes to files and go back to lazyjj. This used to work because we used to do:

```javascript
self.refresh_log_output(commander);
self.refresh_head_output(commander);
```

on focus. After #169 we are now only doing 
```javascript
self.log_panel.set_head(latest_head);
```

That only refreshes the log panel. This PR refresh the details pane too.


