### PR TITLE
fix: Fix crash when current head no longer exists

### DIFF
--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -176,10 +176,16 @@ impl FilesTab {
 
 impl Component for FilesTab {
     fn focus(&mut self, commander: &mut Commander) -> Result<()> {
-        self.is_current_head = self.head == commander.get_current_head()?;
-        self.head = commander.get_head_latest(&self.head)?;
-        self.refresh_files(commander)?;
-        self.refresh_diff(commander)?;
+        match commander.get_head_latest(&self.head) {
+            Ok(latest_head) => {
+                self.head = latest_head;
+                self.is_current_head = self.head == commander.get_current_head()?;
+                self.refresh_files(commander)?;
+                self.refresh_diff(commander)?;
+            }
+            _ => self.set_head(commander, &commander.get_current_head()?)?,
+        }
+
         Ok(())
     }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -437,9 +437,14 @@ impl<'a> LogTab<'a> {
 
 impl Component for LogTab<'_> {
     fn focus(&mut self, commander: &mut Commander) -> Result<()> {
-        let latest_head = commander.get_head_latest(&self.head)?;
-        self.log_panel.set_head(latest_head);
-        self.sync_head_output(commander);
+        match commander.get_head_latest(&self.head) {
+            Ok(latest_head) => {
+                self.log_panel.set_head(latest_head);
+                self.sync_head_output(commander);
+            }
+            _ => self.set_head(commander, commander.get_current_head()?),
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
When e.g. issuing a `jj new` command in a different window that causes the current head to disappear (because it was empty), we currently crash when trying to find the latest version of that head. Instead, we should just switch to the `@` revision in that case.