### PR TITLE
fix: Fix crash & update UI when current head no longer exists

### DIFF
--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -198,6 +198,9 @@ impl Commander {
         let Ok(latest_heads_res) = latest_heads_res else {
             return self.get_head_latest(&self.get_current_head()?);
         };
+        if latest_heads_res.is_empty() {
+            return self.get_head_latest(&self.get_current_head()?);
+        }
         let latest_heads: Vec<Head> = latest_heads_res
             .lines()
             .map(parse_head)

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -438,8 +438,7 @@ impl<'a> LogTab<'a> {
 impl Component for LogTab<'_> {
     fn focus(&mut self, commander: &mut Commander) -> Result<()> {
         let latest_head = commander.get_head_latest(&self.head)?;
-        self.log_panel.set_head(latest_head);
-        self.sync_head_output(commander);
+        self.set_head(commander, latest_head);
         Ok(())
     }
 


### PR DESCRIPTION
When doing a fetch that removes the current head (for instance because you were in a branch that is merged) or issuing a jj command in a different window that causes the current head to disappear (because it was empty), we currently crash when trying to find the latest version of that head.

The problem is that `jj log --no-graph -r luwt` fails if `luwt` does not exist. However, after #181 we do ` jj log --no-graph -r 'change_id(luwt)'` that simply returns empty if `luwt` does not exists.

This fixes this by checking the output was not empty and using `set_head` to update the UI