### PR TITLE
Fix update details on focus

### DIFF
--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -198,6 +198,9 @@ impl Commander {
         let Ok(latest_heads_res) = latest_heads_res else {
             return self.get_head_latest(&self.get_current_head()?);
         };
+        if latest_heads_res.is_empty() {
+            return self.get_head_latest(&self.get_current_head()?);
+        }
         let latest_heads: Vec<Head> = latest_heads_res
             .lines()
             .map(parse_head)

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -130,13 +130,8 @@ impl<'a> LogTab<'a> {
         })
     }
 
-    /// Update change details panel if the selection has changed
+    /// Update change details panel
     fn sync_head_output(&mut self, commander: &mut Commander) {
-        if self.head == self.log_panel.head {
-            // log panel and head panel agree on head
-            return;
-        }
-        // Update head panel to show new head
         self.head = self.log_panel.head.clone();
         self.refresh_head_output(commander);
     }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -438,8 +438,7 @@ impl<'a> LogTab<'a> {
 impl Component for LogTab<'_> {
     fn focus(&mut self, commander: &mut Commander) -> Result<()> {
         let latest_head = commander.get_head_latest(&self.head)?;
-        self.log_panel.set_head(latest_head);
-        self.sync_head_output(commander);
+        self.set_head(commander, latest_head);
         Ok(())
     }
 


### PR DESCRIPTION
When doing a push or a fetch that didn't change the change_id, the pane view (that shows the jj show view in the right) was not refreshed. This meant that even though the push finished you wouldn't see the bookmark from the remote being added to the change.

This PR fixes this while relying on the fix from #188. I guess once we merge #188 I can rebase to only show the fix for this that is only this: https://github.com/Cretezy/lazyjj/pull/189/commits/4fca8230a186fce42ef1417f48f3faef02e64d0b


TBH, I am a bit unsure of the broader impact this skip had in the app. So far in my tests it hasn't been a problem. I will be using this daily and will report back if I find any problems 👍 
